### PR TITLE
remove isModalOpen state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -108,7 +108,7 @@ const App: FunctionalComponent<InitProductPromotion> = ({
 }) => {
   const [productId, setProductId] = useState<string | null>(null);
 
-  useEffect(() => {            setProductId(productId);
+  useEffect(() => {            
 
     initStyles(style);
 


### PR DESCRIPTION
with setting productID to null when pressing x, closing the modal works fine
then is not necessary a isModalOpen state, we need just to check the productId