### PR TITLE
feat(ui): add Button and improve custom styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@
     promoteTargetClassName: "my-custom-promote-target",
       style: {
         button: {
-          className: "my-custom-button",
-        },
-        buttonText: {
-          className: "my-custom-button-text",
-          replace: true,
+          // defaults to "sm"
+          borderRadius: "none" | "sm" | "full"
         },
       },
       text: {
@@ -49,8 +46,6 @@
       },
    );
    ```
-
-   By default, styles applied via custom class names will extend the TopsortElements styles. Use `replace: true` to replace the TopsortElements styles.
 
 1. In your markup, add the following HTML class and data attributes to the element(s) you want a Promote button appended to:
 
@@ -144,3 +139,4 @@
 - put common props (text, style etc) into a context
 - use typescript for demo/loader.js
 - consider not storing apiToken on TopsortElements instance
+- consider accepting `primaryRgb` and `secondaryRgb` as props and set the css vars on our side. Or maybe multiple ways of setting it (consumer in css, consumer in JS, us in JS using props)

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,10 +4,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Topsort Elements Demo</title>
     <style>
-      :root {
+      /* This would be the alternate approach to JS: */
+      /* :root {
         --ts-primary-rgb: 15, 67, 94;
         --ts-secondary-rgb: 255, 255, 255;
-      }
+      } */
 
       body {
         margin: 0;

--- a/demo/loader.js
+++ b/demo/loader.js
@@ -4,7 +4,7 @@
 const imgSize = 160;
 const numProducts = 20;
 const isUsingTopsortElements = true;
-const isUsingCustomProps = false;
+const isUsingCustomProps = true;
 const customPromoteTargetClassName = "my-custom-promote-target";
 
 function getNewElement(selector) {
@@ -65,15 +65,19 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   if (isUsingCustomProps) {
+    document.documentElement.style.setProperty(
+      "--ts-primary-rgb",
+      "15, 67, 94"
+    );
+    document.documentElement.style.setProperty(
+      "--ts-secondary-rgb",
+      "255, 255, 255"
+    );
     tsElements.initProductPromotion({
       promoteTargetClassName: customPromoteTargetClassName,
       style: {
         button: {
-          className: "my-custom-button",
-        },
-        buttonText: {
-          className: "my-custom-button-text",
-          replace: true,
+          borderRadius: "none",
         },
       },
       text: {

--- a/src/app.css
+++ b/src/app.css
@@ -1,47 +1,75 @@
-/* Default variable values */
 :root {
-  --ts-primary-rgb: 0, 4, 42;
+  /* Default primary rgb: */
+  --ts-primary-rgb: 94, 59, 221;
   --ts-primary-color: rgb(var(--ts-primary-rgb));
+  --ts-primary-color-90: rgba(var(--ts-primary-rgb), 0.9);
   --ts-primary-color-60: rgba(var(--ts-primary-rgb), 0.6);
   --ts-primary-color-40: rgba(var(--ts-primary-rgb), 0.4);
   --ts-primary-color-5: rgba(var(--ts-primary-rgb), 0.05);
 
+  /* Default secondary rgb: */
   --ts-secondary-rgb: 221, 214, 255;
   --ts-secondary-color: rgb(var(--ts-secondary-rgb));
   --ts-secondary-color-30: rgba(var(--ts-secondary-rgb), 0.3);
   --ts-secondary-color-10: rgba(var(--ts-secondary-rgb), 0.1);
 
   --ts-border: 0.0625rem solid var(--ts-primary-color);
-  --ts-radius: 0.25rem;
+  --ts-radius: 0.5rem;
 }
 
-/* Promote button */
-.ts-product-promote-button {
-  cursor: pointer;
-  border-radius: var(--ts-radius);
-  background-color: var(--ts-secondary-color);
-  border: var(--ts-border);
-  position: absolute;
-  bottom: 0.5rem;
-  right: 0.5rem;
+.ts-button {
   font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  border: var(--ts-border);
+  padding: 0.5rem 0.75rem;
 }
 
-.ts-product-promote-button__text {
-  font-weight: 600;
+.ts-button--text {
+  border-color: transparent;
+  background-color: transparent;
   color: var(--ts-primary-color);
 }
 
-.ts-product-promote-button:hover {
+.ts-button--text:hover {
+  background-color: var(--ts-primary-color-5);
+}
+
+.ts-button--contained {
   background-color: var(--ts-primary-color);
+  color: #fff;
 }
 
-.ts-product-promote-button:hover .ts-product-promote-button__text {
-  color: var(--ts-secondary-color);
+.ts-button--contained:hover {
+  background-color: var(--ts-primary-color-90);
+  border-color: transparent;
 }
 
-/* Modal */
-.ts-promote-modal {
+.ts-button--outlined {
+  background-color: #fff;
+  color: var(--ts-primary-color);
+}
+
+.ts-button--outlined:hover {
+  background-color: var(--ts-primary-color-5);
+}
+
+.ts-button--rounded-sm {
+  border-radius: var(--ts-radius);
+}
+
+.ts-button--rounded-full {
+  border-radius: 9999px;
+}
+
+.ts-promote-button {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  font-weight: 600;
+}
+
+.ts-modal {
   position: fixed;
   flex-direction: column;
   align-items: center;
@@ -58,11 +86,11 @@
   z-index: 1;
 }
 
-.ts-promote-modal--show {
+.ts-modal--show {
   display: flex;
 }
 
-.ts-promote-modal--hide {
+.ts-modal--hide {
   display: none;
 }
 
@@ -87,7 +115,6 @@
   background-color: var(--ts-primary-color-5);
 }
 
-/* Campaign Creation */
 .ts-campaign-creation {
   display: flex;
   flex-direction: column;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,29 @@
+import { buttonClassName } from "@constants";
+import { Style } from "@types";
+import cx from "classnames";
+import { h, FunctionalComponent, JSX } from "preact";
+
+export const Button: FunctionalComponent<
+  JSX.IntrinsicElements["button"] & {
+    variant: "text" | "contained" | "outlined";
+    // This is temporary to prevent combining with the HTML style prop.
+    // Will be removed once `style` is moved into context.
+    _style?: Style;
+  }
+> = ({ children, className, variant, _style, ...props }) => {
+  const borderRadius = _style?.button?.borderRadius || "sm";
+  return (
+    <button
+      className={cx(buttonClassName, className, {
+        "ts-button--text": variant === "text",
+        "ts-button--contained": variant === "contained",
+        "ts-button--outlined": variant === "outlined",
+        "ts-button--rounded-sm": borderRadius === "sm",
+        "ts-button--rounded-full": borderRadius === "full",
+      })}
+      {...props}
+    >
+      <span>{children}</span>
+    </button>
+  );
+};

--- a/src/components/CampaignCreation.tsx
+++ b/src/components/CampaignCreation.tsx
@@ -1,11 +1,13 @@
+import { Button } from "@components/Button";
 import { campaignCreationClassName, defaultText } from "@constants";
-import { CustomText } from "@types";
+import { CustomText, Style } from "@types";
 import { h, FunctionalComponent } from "preact";
 
 export const CampaignCreation: FunctionalComponent<{
-  text?: CustomText;
   productId: string | null;
-}> = ({ text, productId }) => {
+  style?: Style;
+  text?: CustomText;
+}> = ({ productId, style, text }) => {
   return (
     <div className={campaignCreationClassName}>
       <h2>{text?.modalTitle || defaultText.modalTitle}</h2>
@@ -17,6 +19,18 @@ export const CampaignCreation: FunctionalComponent<{
           defaultText.modalCampaignNamePlaceholder
         }
       />
+      {/* Testing the button variants: */}
+      <div style={{ display: "flex", marginTop: "1rem", gap: "0.5rem" }}>
+        <Button variant="text" _style={style}>
+          Text
+        </Button>
+        <Button variant="contained" _style={style}>
+          Contained
+        </Button>
+        <Button variant="outlined" _style={style}>
+          Outlined
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,23 +4,21 @@ import {
   modalHideClassName,
   modalShowClassName,
 } from "@constants";
-import { CustomText, Style } from "@types";
+import { CustomText } from "@types";
 import cx from "classnames";
 import { h, FunctionalComponent } from "preact";
 
 // TODO(christopherbot) add overlay behind modal and focus trap
 export const Modal: FunctionalComponent<{
-  style?: Style;
   text?: CustomText;
   onClose: () => void;
   isOpen: boolean;
-}> = ({ style, children, onClose, isOpen }) => {
+}> = ({ children, onClose, isOpen }) => {
   return (
     <div
       role="dialog"
       aria-modal
-      className={cx(style?.modal?.className, {
-        [modalClassName]: !style?.modal?.replace,
+      className={cx(modalClassName, {
         [modalHideClassName]: !isOpen,
         [modalShowClassName]: isOpen,
       })}

--- a/src/components/PromoteButton.tsx
+++ b/src/components/PromoteButton.tsx
@@ -1,27 +1,21 @@
-import { buttonClassName, buttonTextClassName, defaultText } from "@constants";
+import { Button } from "@components/Button";
+import { promoteButtonClassName, defaultText } from "@constants";
 import { CustomText, Style } from "@types";
-import cx from "classnames";
 import { h, FunctionalComponent } from "preact";
 
 export const PromoteButton: FunctionalComponent<{
+  onClick: () => void;
   style?: Style;
   text?: CustomText;
-  onClick: () => void;
-}> = ({ style, text, onClick }) => {
+}> = ({ onClick, text, style }) => {
   return (
-    <button
-      className={cx(style?.button?.className, {
-        [buttonClassName]: !style?.button?.replace,
-      })}
+    <Button
+      className={promoteButtonClassName}
+      variant="outlined"
       onClick={onClick}
+      _style={style}
     >
-      <span
-        className={cx(style?.buttonText?.className, {
-          [buttonTextClassName]: !style?.buttonText?.replace,
-        })}
-      >
-        {text?.button || defaultText.button}
-      </span>
-    </button>
+      {text?.button || defaultText.promoteButton}
+    </Button>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 /* Text */
 export const defaultText = {
-  button: "Promote",
+  promoteButton: "Promote",
   modalTitle: "Create Campaign",
   modalSubtitle: "Quickly launch a campaign for this product.",
   modalCampaignNamePlaceholder: "Enter your campaign name",
@@ -14,14 +14,10 @@ export const defaultPromoteTargetClassName = "ts-promote-target";
  * CSS Class Names
  * These should match the classes in app.css
  */
-// Promote button
-export const buttonClassName = "ts-product-promote-button";
-export const buttonTextClassName = "ts-product-promote-button__text";
-// Modal
-export const modalClassName = "ts-promote-modal";
-export const modalShowClassName = "ts-promote-modal--show";
-export const modalHideClassName = "ts-promote-modal--hide";
-// Common
+export const buttonClassName = "ts-button";
+export const promoteButtonClassName = "ts-promote-button";
+export const modalClassName = "ts-modal";
+export const modalShowClassName = "ts-modal--show";
+export const modalHideClassName = "ts-modal--hide";
 export const closeButtonClassName = "ts-close-button";
-// Campaign Creation
 export const campaignCreationClassName = "ts-campaign-creation";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,14 +64,13 @@ const App: FunctionalComponent<InitProductPromotion> = ({
   return (
     <Portal>
       <Modal
-        style={style}
         text={text}
         onClose={() => {
           setProductId(null);
         }}
         isOpen={!!productId}
       >
-        <CampaignCreation text={text} productId={productId} />
+        <CampaignCreation text={text} productId={productId} style={style} />
       </Modal>
     </Portal>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,8 @@
-type CustomClassName = {
-  className: string;
-  replace?: boolean;
-};
-
-export type Style = Partial<
-  Record<"button" | "buttonText" | "modal", CustomClassName>
->;
+export type Style = Partial<{
+  button: {
+    borderRadius: "none" | "sm" | "full";
+  };
+}>;
 
 export type CustomText = Partial<
   Record<


### PR DESCRIPTION
This creates a base Button component with variants and controls its own
border radius based on the style prop from the consumer.

Unhovered & no `borderRadius`, which defaults to `"sm"`

<img width="249" alt="Screen Shot 2022-08-24 at 3 44 56 PM" src="https://user-images.githubusercontent.com/23301657/186539565-db5f5481-b5d2-4356-9cc1-5f9474bc6585.png">

Hovered:

<img width="254" alt="Screen Shot 2022-08-24 at 3 45 06 PM" src="https://user-images.githubusercontent.com/23301657/186539568-59d10ccc-4da9-4621-a04c-bcd08e66be7d.png">

Unhovered (except "Text" is hovered to show the border radius) & `borderRadius: "none"`:

<img width="262" alt="Screen Shot 2022-08-24 at 4 02 15 PM" src="https://user-images.githubusercontent.com/23301657/186539571-14927632-8b1b-4e24-bd6c-16870e11ab53.png">

Default (except "Text" is hovered to show the border radius) & `borderRadius: "full"`:

<img width="261" alt="Screen Shot 2022-08-24 at 4 02 32 PM" src="https://user-images.githubusercontent.com/23301657/186539572-1adfaee3-054c-47e5-b7ae-302539adeffc.png">


