### PR TITLE
fix: apply custom border radius to close button

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -105,11 +105,6 @@
   height: 1.75rem;
 }
 
-.ts-close-button span {
-  color: var(--ts-primary-color);
-  font-size: 1rem;
-}
-
 .ts-close-button:hover {
   background-color: var(--ts-primary-color-5);
 }
@@ -118,4 +113,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.ts-svg-wrapper {
+  display: flex;
+}
+
+.ts-rotate-45 {
+  transform: rotate(45deg);
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,7 +21,7 @@ export const Button: FunctionalComponent<
       })}
       {...props}
     >
-      <span>{children}</span>
+      {children}
     </button>
   );
 };

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@components/Button";
+import { Icon } from "@components/Icon";
 import { closeButtonClassName } from "@constants";
 import cx from "classnames";
 import { h, FunctionalComponent, JSX } from "preact";
@@ -12,7 +13,7 @@ export const CloseButton: FunctionalComponent<
       variant="text"
       {...props}
     >
-      ✕
+      <Icon className="ts-rotate-45" name="plus" title="Close" />
     </Button>
   );
 };

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,0 +1,26 @@
+import { Svg, SvgProps } from "@components/Svg";
+import { Plus } from "@components/icons/Plus";
+import { h, FunctionalComponent } from "preact";
+import { useMemo } from "preact/hooks";
+
+const icons = {
+  plus: Plus,
+};
+
+type IconName = keyof typeof icons;
+
+export const Icon: FunctionalComponent<
+  SvgProps & {
+    name: IconName;
+  }
+> = ({ name, ...props }) => {
+  const IconComponent = useMemo(() => icons[name], [name]);
+
+  if (!IconComponent) return <div />;
+
+  return (
+    <Svg {...props}>
+      <IconComponent />
+    </Svg>
+  );
+};

--- a/src/components/Svg.tsx
+++ b/src/components/Svg.tsx
@@ -1,0 +1,52 @@
+import { h, FunctionalComponent, JSX } from "preact";
+import { useMemo } from "preact/hooks";
+
+type A11yProps = {
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+};
+
+export type SvgProps = JSX.IntrinsicElements["svg"] & {
+  description?: string;
+};
+
+let numId = 0;
+
+export const Svg: FunctionalComponent<SvgProps> = ({
+  title,
+  description,
+  children,
+  fill = "none",
+  ...props
+}) => {
+  const id = useMemo(() => numId++, []);
+  const a11yProps: A11yProps = {};
+  const titleId = `ts-svg-title-id-${title}-${id}`;
+  const descriptionId = `ts-svg-description-id-${description}-${id}`;
+
+  if (title) {
+    a11yProps["aria-labelledby"] = titleId;
+  }
+  if (description) {
+    a11yProps["aria-describedby"] = descriptionId;
+  }
+
+  return (
+    <div className="ts-svg-wrapper">
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill={fill}
+        role="img"
+        xmlns="http://www.w3.org/2000/svg"
+        {...a11yProps}
+        {...props}
+      >
+        {title && <title id={titleId}>{title}</title>}
+        {description && <desc id={descriptionId}>{description}</desc>}
+        {children}
+      </svg>
+    </div>
+  );
+};

--- a/src/components/icons/Plus.tsx
+++ b/src/components/icons/Plus.tsx
@@ -1,0 +1,20 @@
+import { h, Fragment } from "preact";
+
+export const Plus = () => (
+  <Fragment>
+    <path
+      d="M6 12H18"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 18V6"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </Fragment>
+);


### PR DESCRIPTION
Uses the `Button` component for the CloseButton to apply the custom border radius styles for consistency.

None:

<img width="484" alt="Screen Shot 2022-08-30 at 7 28 22 AM" src="https://user-images.githubusercontent.com/23301657/187464485-2400c5b4-94cd-4ec0-baf3-4fd9289e836c.png">

Full:

<img width="557" alt="Screen Shot 2022-08-30 at 7 28 39 AM" src="https://user-images.githubusercontent.com/23301657/187464499-5b424681-045a-460e-b78d-ee744ae5aa6e.png">
