### PR TITLE
fix(campaign creation): prevent infinite rerenders

### DIFF
--- a/src/components/CampaignCreation/index.tsx
+++ b/src/components/CampaignCreation/index.tsx
@@ -41,7 +41,7 @@ export const CampaignCreation: FunctionalComponent<{
       type: "payment methods received",
       payload: { paymentMethods: [] },
     });
-  });
+  }, [dispatch]);
 
   useEffect(() => {
     // If the modal for a different product is opened,

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -44,7 +44,8 @@ export const Modal: FunctionalComponent<{
     return () => {
       document.removeEventListener("keydown", onKeydown);
     };
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Some useEffects had no dependency arrays which is effectively the same as re-running on every prop change. This was causing infinite rerenders in the campaign creation component.

Before:

<img width="722" alt="Screen Shot 2022-09-23 at 11 29 40 AM" src="https://user-images.githubusercontent.com/23301657/192034064-a2e3de6b-b598-4cf8-84cd-3ee71173d48f.png">

After:

<img width="729" alt="Screen Shot 2022-09-23 at 11 28 42 AM" src="https://user-images.githubusercontent.com/23301657/192034075-c3318d3e-01d0-4efb-b75b-8d6bd6aa9d7e.png">
