### PR TITLE
feat: differentiate active from inactive products

### DIFF
--- a/demo/loader.js
+++ b/demo/loader.js
@@ -4,7 +4,7 @@
 const imgSize = 160;
 const numProducts = 20;
 const isUsingTopsortBlocks = true;
-const isUsingCustomProps = false;
+const isUsingCustomProps = true;
 const customPromoteTargetClassName = "my-custom-promote-target";
 
 function getNewElement(selector) {
@@ -38,7 +38,11 @@ function createProductElement(num) {
       ? customPromoteTargetClassName
       : TopsortBlocks.promoteTargetClassName
   );
-  target.dataset.tsProductId = `product-${num}`;
+
+  // To demo no Promote button for product 7
+  if (num !== 7) {
+    target.dataset.tsProductId = `product-${num}`;
+  }
 
   return product;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,8 +5,13 @@ async function request(url: string, config?: RequestInit) {
   if (!window.fetch) {
     throw "[fetch] Your browser does not support this function";
   }
-  const res = await window.fetch(url, config);
-  return res.json();
+  const response = await window.fetch(url, config);
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  return response.json();
 }
 
 export async function api<T>(

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -1,4 +1,6 @@
 export default {
   validate: (vendorId: string) =>
     `${CENTRAL_SERVICES_PUBLIC_URL}/auth/vendors/${vendorId}`,
+  vendorProducts: (vendorId: string) =>
+    `${CENTRAL_SERVICES_URL}/vendors/${vendorId}/products`,
 };

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -3,3 +3,14 @@ import { z } from "zod";
 export const validateVendorResponseSchema = z.object({
   authToken: z.string(),
 });
+export type ValidateVendorResponse = z.infer<
+  typeof validateVendorResponseSchema
+>;
+
+export const vendorCampaignIdsByProductIdResponseSchema = z.record(
+  z.string(),
+  z.string().nullable()
+);
+export type VendorCampaignIdsByProductIdResponse = z.infer<
+  typeof vendorCampaignIdsByProductIdResponseSchema
+>;

--- a/src/components/Button/PromoteButton.tsx
+++ b/src/components/Button/PromoteButton.tsx
@@ -1,18 +1,42 @@
 import { Button } from "@components/Button";
 import { defaultText } from "@constants";
 import { useProductPromotion } from "@context";
+import { RequestStatus } from "@types";
 import { h, FunctionalComponent } from "preact";
 
 export const PromoteButton: FunctionalComponent<{
   onClick: () => void;
+  status: RequestStatus;
   hasCampaign?: boolean;
-}> = ({ onClick, hasCampaign = false }) => {
+}> = ({ onClick, status, hasCampaign = false }) => {
   const { text } = useProductPromotion();
+  const content = (() => {
+    switch (status) {
+      case "pending":
+        return "Loading...";
+      case "error":
+        return "Error";
+      default:
+        return hasCampaign
+          ? text.detailButton || defaultText.detailButton
+          : text.promoteButton || defaultText.promoteButton;
+    }
+  })();
+
+  const disabled = status === "pending" || status === "error";
+
   return (
-    <Button className="ts-promote-button" variant="outlined" onClick={onClick}>
-      {hasCampaign
-        ? text.detailButton || defaultText.detailButton
-        : text.promoteButton || defaultText.promoteButton}
+    <Button
+      className="ts-promote-button"
+      variant="outlined"
+      onClick={() => {
+        if (!disabled) {
+          onClick();
+        }
+      }}
+      disabled={disabled}
+    >
+      {content}
     </Button>
   );
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,8 @@ import { createContext } from "preact";
 import { useContext } from "preact/hooks";
 
 type ProductPromotionContextValue = {
+  authToken: string;
+  vendorId: string;
   promoteTargetClassName: string;
   style: Style;
   text: CustomText;
@@ -10,6 +12,8 @@ type ProductPromotionContextValue = {
 
 export const ProductPromotionContext =
   createContext<ProductPromotionContextValue>({
+    authToken: "",
+    vendorId: "",
     promoteTargetClassName: "",
     style: {},
     text: {},

--- a/src/hooks/use-async.ts
+++ b/src/hooks/use-async.ts
@@ -1,0 +1,42 @@
+import { RequestStatus } from "@types";
+import { useCallback, useEffect, useState } from "preact/hooks";
+
+// https://github.com/uidotdev/usehooks/blob/master/src/pages/useAsync.md
+export const useAsync = <T, E = string>(
+  asyncFunction: () => Promise<T>,
+  immediate = true
+) => {
+  const [status, setStatus] = useState<RequestStatus>("idle");
+  const [value, setValue] = useState<T | null>(null);
+  const [error, setError] = useState<E | null>(null);
+
+  // The execute function wraps asyncFunction and
+  // handles setting state for pending, value, and error.
+  // useCallback ensures the below useEffect is not called
+  // on every render, but only if asyncFunction changes.
+  const execute = useCallback(async () => {
+    setStatus("pending");
+    setValue(null);
+    setError(null);
+
+    try {
+      const response = await asyncFunction();
+      setValue(response);
+      setStatus("success");
+    } catch (error: any) {
+      setError(error);
+      setStatus("error");
+    }
+  }, [asyncFunction]);
+
+  // Call execute if we want to fire it right away.
+  // Otherwise execute can be called later, such as
+  // in an onClick handler.
+  useEffect(() => {
+    if (immediate) {
+      execute();
+    }
+  }, [execute, immediate]);
+
+  return { execute, status, value, error };
+};

--- a/src/services/central-services/index.ts
+++ b/src/services/central-services/index.ts
@@ -6,11 +6,15 @@ function getAuthorizationHeader(apiKey: string) {
   return { authorization: `Bearer ${apiKey}` };
 }
 
+function getAuthTokenHeader(authToken: string) {
+  return { authToken: `Bearer ${authToken}` };
+}
+
 export async function validateVendor(
   apiKey: string,
   vendorId: string
-): Promise<string> {
-  const { authToken } = await api(
+): Promise<schemas.ValidateVendorResponse> {
+  return await api(
     schemas.validateVendorResponseSchema,
     paths.validate(vendorId),
     {
@@ -18,5 +22,29 @@ export async function validateVendor(
       headers: getAuthorizationHeader(apiKey),
     }
   );
-  return authToken;
+}
+
+export async function getVendorCampaignIdsByProductId(
+  authToken: string,
+  vendorId: string,
+  productIds: string[]
+): Promise<schemas.VendorCampaignIdsByProductIdResponse> {
+  /*
+   * TODO(christopherbot) uncomment this to test a "success" or "failure"
+   * of this endpoint since it's not merged yet in Central Services. Will
+   * remove this code when the CS work is merged.
+   */
+  // return new Promise((res, rej) => {
+  //   setTimeout(() => res({ "product-1": "campaign-id" }), 2000);
+  //   // setTimeout(() => rej("Error!!"), 2000);
+  // });
+  return await api(
+    schemas.vendorCampaignIdsByProductIdResponseSchema,
+    paths.vendorProducts(vendorId),
+    {
+      method: "POST",
+      headers: getAuthTokenHeader(authToken),
+      body: JSON.stringify({ productIds }),
+    }
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,5 @@ export type Campaign = {
 };
 
 export type PropsWithChildren<T> = T & { children?: ComponentChildren };
+
+export type RequestStatus = "idle" | "pending" | "success" | "error";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       "@components/*": ["src/components/*"],
       "@constants": ["src/constants"],
       "@context": ["src/context"],
+      "@hooks/*": ["src/hooks/*"],
       "@services/*": ["src/services/*"],
       "@types": ["src/types"],
       "@utils/*": ["src/utils/*"]

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,6 +62,7 @@ module.exports = {
       "@components": path.resolve(__dirname, "src/components/"),
       "@constants": path.resolve(__dirname, "src/constants"),
       "@context": path.resolve(__dirname, "src/context"),
+      "@hooks": path.resolve(__dirname, "src/hooks/"),
       "@services": path.resolve(__dirname, "src/services/"),
       "@types": path.resolve(__dirname, "src/types"),
       "@utils": path.resolve(__dirname, "src/utils/"),


### PR DESCRIPTION
This fetches the vendor's productId-campaignId map to determine which products should show a "Promote" button vs. a "See Campaign" button.

This also adds loading and error states to the Promote button with placeholder UI until further designs can be done.

ADTYPE-410

---

### Request payload - notice that `product-7` is missing from the list because I've omitted adding the productId data attribute to it:

<img width="309" alt="Screen Shot 2022-09-30 at 11 30 04 AM" src="https://user-images.githubusercontent.com/23301657/193334182-d2d543f0-ea3a-47f3-973b-4f349d9cd669.png">


### Loading:

<img width="1024" alt="Screen Shot 2022-09-30 at 11 28 48 AM" src="https://user-images.githubusercontent.com/23301657/193333997-9c64d13f-3d3c-4b76-9962-dd4abad2861a.png">

### "Promote" or "See Campaign" buttons rendered based on API response:

<img width="944" alt="Screen Shot 2022-09-30 at 11 29 03 AM" src="https://user-images.githubusercontent.com/23301657/193334029-90f50d8f-30d3-46c9-b7c4-eb0c00549d1a.png">

### Error:

<img width="1020" alt="Screen Shot 2022-09-30 at 11 29 44 AM" src="https://user-images.githubusercontent.com/23301657/193334120-8ec5e582-a4d1-4974-acf6-86d9c6425717.png">
