### PR TITLE
feat(demo): add ability to use Luma products

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -21,23 +21,43 @@
 
       .title-row {
         display: flex;
-        padding: 0.5rem;
+        flex-direction: column;
+        align-items: flex-end;
+        position: sticky;
+        top: 0;
+        background-color: white;
+        border-bottom: 1px solid #eeeeee;
+        z-index: 1;
+        padding-top: 1rem;
+        gap: 1rem;
       }
 
-      .title-row span {
+      .search-input {
+        width: 15rem;
+        height: 1.5rem;
+        padding: 0 0.5rem;
+      }
+
+      .title-row-headers {
+        display: flex;
+        padding: 0.5rem;
+        width: 100%;
+      }
+
+      .title-row-headers span {
         flex: 0.5;
         text-align: center;
       }
 
-      .title-row span:nth-child(1) {
+      .title-row-headers span:nth-child(1) {
         flex: 1;
       }
 
-      .title-row span:nth-child(4) {
+      .title-row-headers span:nth-child(4) {
         min-width: 12rem;
       }
 
-      .title-row span:nth-child(5) {
+      .title-row-headers span:nth-child(5) {
         text-align: end;
       }
 
@@ -54,6 +74,10 @@
         max-width: 75rem;
       }
 
+      .product-hide {
+        display: none;
+      }
+
       .product:last-child {
         border-bottom: 1px solid #eeeeee;
       }
@@ -67,6 +91,7 @@
       }
 
       .product-img {
+        object-fit: contain;
         width: 4.5rem;
         height: 4.5rem;
       }
@@ -114,11 +139,18 @@
     <main>
       <div class="wrapper">
         <div class="title-row">
-          <span>Name / Code</span>
-          <span>Price</span>
-          <span>Quantity</span>
-          <span></span>
-          <span>Status</span>
+          <input
+            id="product-search"
+            class="search-input"
+            placeholder="Search products"
+          />
+          <div class="title-row-headers">
+            <span>Name / Code</span>
+            <span>Price</span>
+            <span>Quantity</span>
+            <span><!-- purposely empty --></span>
+            <span>Status</span>
+          </div>
         </div>
         <!-- REUSABLE ELEMENTS -->
         <div hidden id="product-proto" class="product">
@@ -139,6 +171,6 @@
         <!-- END REUSABLE ELEMENTS -->
       </div>
     </main>
-    <script src="./loader.js"></script>
+    <script type="module" src="loader.js"></script>
   </body>
 </html>

--- a/demo/lumaProducts.js
+++ b/demo/lumaProducts.js
@@ -1,0 +1,1316 @@
+export const lumaProducts = [
+  {
+    id: "WH12",
+    url: "https://demo.topsort.com/circe-hooded-ice-fleece.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh12-gray_main_1.jpg",
+    name: "Circe Hooded Ice Fleece",
+    price: 68,
+    quantity: 7,
+  },
+  {
+    id: "WH11",
+    url: "https://demo.topsort.com/eos-v-neck-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh11-blue_main_1.jpg",
+    name: "Eos V-Neck Hoodie",
+    price: 54,
+    quantity: 15,
+  },
+  {
+    id: "WH10",
+    url: "https://demo.topsort.com/helena-hooded-fleece.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh10-gray_main_1.jpg",
+    name: "Helena Hooded Fleece",
+    price: 55,
+    quantity: 6,
+  },
+  {
+    id: "WH09",
+    url: "https://demo.topsort.com/ariel-roll-sleeve-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh09-purple_main_1.jpg",
+    name: "Ariel Roll Sleeve Sweatshirt",
+    price: 39,
+    quantity: 19,
+  },
+  {
+    id: "WH08",
+    url: "https://demo.topsort.com/cassia-funnel-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh08-white_main_1.jpg",
+    name: "Cassia Funnel Sweatshirt",
+    price: 48,
+    quantity: 1,
+  },
+  {
+    id: "WH07",
+    url: "https://demo.topsort.com/phoebe-zipper-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh07-gray_main_1.jpg",
+    name: "Phoebe Zipper Sweatshirt",
+    price: 59,
+    quantity: 17,
+  },
+  {
+    id: "WH06",
+    url: "https://demo.topsort.com/daphne-full-zip-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh06-purple_main_1.jpg",
+    name: "Daphne Full-Zip Hoodie",
+    price: 59,
+    quantity: 10,
+  },
+  {
+    id: "WH05",
+    url: "https://demo.topsort.com/selene-yoga-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh05-white_main_1.jpg",
+    name: "Selene Yoga Hoodie",
+    price: 42,
+    quantity: 18,
+  },
+  {
+    id: "WH04",
+    url: "https://demo.topsort.com/miko-pullover-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh04-blue_main_1.jpg",
+    name: "Miko Pullover Hoodie",
+    price: 69,
+    quantity: 24,
+  },
+  {
+    id: "WH03",
+    url: "https://demo.topsort.com/autumn-pullie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh03-red_main_1.jpg",
+    name: "Autumn Pullie",
+    price: 57,
+    quantity: 24,
+  },
+  {
+    id: "WH02",
+    url: "https://demo.topsort.com/hera-pullover-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh02-blue_main_2.jpg",
+    name: "Hera Pullover Hoodie",
+    price: 48,
+    quantity: 24,
+  },
+  {
+    id: "WH01",
+    url: "https://demo.topsort.com/mona-pullover-hoodlie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/h/wh01-green_main_1.jpg",
+    name: "Mona Pullover Hoodlie",
+    price: 57,
+    quantity: 6,
+  },
+  {
+    id: "WJ12",
+    url: "https://demo.topsort.com/olivia-1-4-zip-light-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj12-blue_main_1.jpg",
+    name: "Olivia 1/4 Zip Light Jacket",
+    price: 77,
+    quantity: 4,
+  },
+  {
+    id: "WJ06",
+    url: "https://demo.topsort.com/juno-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj06-purple_main_1.jpg",
+    name: "Juno Jacket",
+    price: 77,
+    quantity: 22,
+  },
+  {
+    id: "WJ11",
+    url: "https://demo.topsort.com/neve-studio-dance-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj11-blue_main_1.jpg",
+    name: "Neve Studio Dance Jacket",
+    price: 69,
+    quantity: 22,
+  },
+  {
+    id: "WJ10",
+    url: "https://demo.topsort.com/nadia-elements-shell.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj10-yellow_main_2.jpg",
+    name: "Nadia Elements Shell",
+    price: 69,
+    quantity: 15,
+  },
+  {
+    id: "WJ09",
+    url: "https://demo.topsort.com/jade-yoga-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj09-green_main_1.jpg",
+    name: "Jade Yoga Jacket",
+    price: 32,
+    quantity: 11,
+  },
+  {
+    id: "WJ08",
+    url: "https://demo.topsort.com/adrienne-trek-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj08-gray_main_1.jpg",
+    name: "Adrienne Trek Jacket",
+    price: 57,
+    quantity: 22,
+  },
+  {
+    id: "WJ07",
+    url: "https://demo.topsort.com/inez-full-zip-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj07-purple_main_1.jpg",
+    name: "Inez Full Zip Jacket",
+    price: 59,
+    quantity: 25,
+  },
+  {
+    id: "WJ05",
+    url: "https://demo.topsort.com/riona-full-zip-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj05-brown_main_1.jpg",
+    name: "Riona Full Zip Jacket",
+    price: 60,
+    quantity: 25,
+  },
+  {
+    id: "WJ04",
+    url: "https://demo.topsort.com/ingrid-running-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj04-white_main_1.jpg",
+    name: "Ingrid Running Jacket",
+    price: 84,
+    quantity: 14,
+  },
+  {
+    id: "WJ03",
+    url: "https://demo.topsort.com/augusta-pullover-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj03-red_main_2.jpg",
+    name: "Augusta Pullover Jacket",
+    price: 57,
+    quantity: 4,
+  },
+  {
+    id: "WJ02",
+    url: "https://demo.topsort.com/josie-yoga-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj02-gray_main_1.jpg",
+    name: "Josie Yoga Jacket",
+    price: 56.25,
+    quantity: 20,
+  },
+  {
+    id: "WJ01",
+    url: "https://demo.topsort.com/stellar-solar-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj01-red_main_1.jpg",
+    name: "Stellar Solar Jacket",
+    price: 75,
+    quantity: 25,
+  },
+  {
+    id: "WJ09",
+    url: "https://demo.topsort.com/jade-yoga-jacket.html?auction_id=0634065d-b1e6-7611-a304-faeaf0c5341e",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj09-green_main_1.jpg",
+    name: "Jade Yoga Jacket",
+    price: 32,
+    quantity: 2,
+  },
+  {
+    id: "WJ06",
+    url: "https://demo.topsort.com/juno-jacket.html?auction_id=0634065d-b1e6-7611-a304-faeaf0c5341e",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/j/wj06-purple_main_1.jpg",
+    name: "Juno Jacket",
+    price: 77,
+    quantity: 3,
+  },
+  {
+    id: "WS05",
+    url: "https://demo.topsort.com/desiree-fitness-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws05-black_main_1.jpg",
+    name: "Desiree Fitness Tee",
+    price: 24,
+    quantity: 21,
+  },
+  {
+    id: "WS01",
+    url: "https://demo.topsort.com/gwyn-endurance-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws01-black_main_1.jpg",
+    name: "Gwyn Endurance Tee",
+    price: 24,
+    quantity: 7,
+  },
+  {
+    id: "WS12",
+    url: "https://demo.topsort.com/radiant-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws12-orange_main_2.jpg",
+    name: "Radiant Tee",
+    price: 22,
+    quantity: 21,
+  },
+  {
+    id: "WS11",
+    url: "https://demo.topsort.com/diva-gym-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws11-yellow_main_1.jpg",
+    name: "Diva Gym Tee",
+    price: 32,
+    quantity: 8,
+  },
+  {
+    id: "WS10",
+    url: "https://demo.topsort.com/karissa-v-neck-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws10-red_main_1.jpg",
+    name: "Karissa V-Neck Tee",
+    price: 32,
+    quantity: 3,
+  },
+  {
+    id: "WS09",
+    url: "https://demo.topsort.com/tiffany-fitness-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws09-blue_main_1.jpg",
+    name: "Tiffany Fitness Tee",
+    price: 28,
+    quantity: 20,
+  },
+  {
+    id: "WS08",
+    url: "https://demo.topsort.com/minerva-lumatech-trade-v-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws08-blue_main_1.jpg",
+    name: "Minerva LumaTech™ V-Tee",
+    price: 32,
+    quantity: 12,
+  },
+  {
+    id: "WS07",
+    url: "https://demo.topsort.com/juliana-short-sleeve-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws07-black_main_1.jpg",
+    name: "Juliana Short-Sleeve Tee",
+    price: 42,
+    quantity: 17,
+  },
+  {
+    id: "WS06",
+    url: "https://demo.topsort.com/elisa-evercool-trade-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws06-purple_main_2.jpg",
+    name: "Elisa EverCool™ Tee",
+    price: 29,
+    quantity: 14,
+  },
+  {
+    id: "WS04",
+    url: "https://demo.topsort.com/layla-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws04-green_main_1.jpg",
+    name: "Layla Tee",
+    price: 29,
+    quantity: 13,
+  },
+  {
+    id: "WS03",
+    url: "https://demo.topsort.com/iris-workout-top.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws03-red_main_1.jpg",
+    name: "Iris Workout Top",
+    price: 29,
+    quantity: 1,
+  },
+  {
+    id: "WS02",
+    url: "https://demo.topsort.com/gabrielle-micro-sleeve-top.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/ws02-green_main_1.jpg",
+    name: "Gabrielle Micro Sleeve Top",
+    price: 28,
+    quantity: 8,
+  },
+  {
+    id: "WT07",
+    url: "https://demo.topsort.com/maya-tunic.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt07-green_main_1.jpg",
+    name: "Maya Tunic",
+    price: 29,
+    quantity: 17,
+  },
+  {
+    id: "WT06",
+    url: "https://demo.topsort.com/chloe-compete-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt06-blue_main_1.jpg",
+    name: "Chloe Compete Tank",
+    price: 39,
+    quantity: 3,
+  },
+  {
+    id: "WT05",
+    url: "https://demo.topsort.com/leah-yoga-top.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt05-purple_main_2.jpg",
+    name: "Leah Yoga Top",
+    price: 39,
+    quantity: 22,
+  },
+  {
+    id: "WT04",
+    url: "https://demo.topsort.com/nona-fitness-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt04-blue_main_1.jpg",
+    name: "Nona Fitness Tank",
+    price: 39,
+    quantity: 23,
+  },
+  {
+    id: "WT03",
+    url: "https://demo.topsort.com/nora-practice-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt03-red_main_1.jpg",
+    name: "Nora Practice Tank",
+    price: 39,
+    quantity: 18,
+  },
+  {
+    id: "WT02",
+    url: "https://demo.topsort.com/zoe-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt02-orange_main_1.jpg",
+    name: "Zoe Tank",
+    price: 29,
+    quantity: 10,
+  },
+  {
+    id: "WT01",
+    url: "https://demo.topsort.com/bella-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/t/wt01-blue_main_1.jpg",
+    name: "Bella Tank",
+    price: 29,
+    quantity: 19,
+  },
+  {
+    id: "WB05",
+    url: "https://demo.topsort.com/lucia-cross-fit-bra.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/b/wb05-black_main_1.jpg",
+    name: "Lucia Cross-Fit Bra",
+    price: 39,
+    quantity: 14,
+  },
+  {
+    id: "WB04",
+    url: "https://demo.topsort.com/prima-compete-bra-top.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/b/wb04-blue_main_2.jpg",
+    name: "Prima Compete Bra Top",
+    price: 24,
+    quantity: 6,
+  },
+  {
+    id: "WB03",
+    url: "https://demo.topsort.com/celeste-sports-bra.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/b/wb03-green_main_1.jpg",
+    name: "Celeste Sports Bra",
+    price: 39,
+    quantity: 9,
+  },
+  {
+    id: "WB02",
+    url: "https://demo.topsort.com/erica-evercool-sports-bra.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/b/wb02-blue_main_1.jpg",
+    name: "Erica Evercool Sports Bra",
+    price: 39,
+    quantity: 15,
+  },
+  {
+    id: "WB01",
+    url: "https://demo.topsort.com/electra-bra-top.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/b/wb01-gray_main_1.jpg",
+    name: "Electra Bra Top",
+    price: 39,
+    quantity: 23,
+  },
+  {
+    id: "WP12",
+    url: "https://demo.topsort.com/deirdre-relaxed-fit-capri.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp12-gray_main_1.jpg",
+    name: "Deirdre Relaxed-Fit Capri",
+    price: 63,
+    quantity: 14,
+  },
+  {
+    id: "WP11",
+    url: "https://demo.topsort.com/sylvia-capri.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp11-green_main_1.jpg",
+    name: "Sylvia Capri",
+    price: 42,
+    quantity: 4,
+  },
+  {
+    id: "WP10",
+    url: "https://demo.topsort.com/daria-bikram-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp10-gray_main_1.jpg",
+    name: "Daria Bikram Pant",
+    price: 51,
+    quantity: 15,
+  },
+  {
+    id: "WP09",
+    url: "https://demo.topsort.com/carina-basic-capri.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp09-black_main_1.jpg",
+    name: "Carina Basic Capri",
+    price: 51,
+    quantity: 22,
+  },
+  {
+    id: "WP08",
+    url: "https://demo.topsort.com/bardot-capri.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp08-black_main_1.jpg",
+    name: "Bardot Capri",
+    price: 48,
+    quantity: 9,
+  },
+  {
+    id: "WP07",
+    url: "https://demo.topsort.com/aeon-capri.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp07-black_main_1.jpg",
+    name: "Aeon Capri",
+    price: 48,
+    quantity: 18,
+  },
+  {
+    id: "WP06",
+    url: "https://demo.topsort.com/diana-tights.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp06-black_main_1.jpg",
+    name: "Diana Tights",
+    price: 59,
+    quantity: 2,
+  },
+  {
+    id: "WP05",
+    url: "https://demo.topsort.com/sahara-leggings.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp05-gray_main_2.jpg",
+    name: "Sahara Leggings",
+    price: 75,
+    quantity: 22,
+  },
+  {
+    id: "WP04",
+    url: "https://demo.topsort.com/cora-parachute-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp04-blue_main_1.jpg",
+    name: "Cora Parachute Pant",
+    price: 75,
+    quantity: 21,
+  },
+  {
+    id: "WP03",
+    url: "https://demo.topsort.com/ida-workout-parachute-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp03-blue_main_1.jpg",
+    name: "Ida Workout Parachute Pant",
+    price: 48,
+    quantity: 2,
+  },
+  {
+    id: "WP02",
+    url: "https://demo.topsort.com/emma-leggings.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp02-blue_main_1.jpg",
+    name: "Emma Leggings",
+    price: 42,
+    quantity: 4,
+  },
+  {
+    id: "WP01",
+    url: "https://demo.topsort.com/karmen-yoga-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp01-gray_main_1.jpg",
+    name: "Karmen Yoga Pant",
+    price: 39,
+    quantity: 12,
+  },
+  {
+    id: "WP12",
+    url: "https://demo.topsort.com/deirdre-relaxed-fit-capri.html?auction_id=06340674-6990-7d18-8b04-fb10f0c5341e",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/p/wp12-gray_main_1.jpg",
+    name: "Deirdre Relaxed-Fit Capri",
+    price: 63,
+    quantity: 12,
+  },
+  {
+    id: "WSH12",
+    url: "https://demo.topsort.com/erika-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh12-green_main_1.jpg",
+    name: "Erika Running Short",
+    price: 45,
+    quantity: 11,
+  },
+  {
+    id: "WSH11",
+    url: "https://demo.topsort.com/ina-compression-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh11-blue_main_1.jpg",
+    name: "Ina Compression Short",
+    price: 49,
+    quantity: 7,
+  },
+  {
+    id: "WSH10",
+    url: "https://demo.topsort.com/ana-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh10-black_main_1.jpg",
+    name: "Ana Running Short",
+    price: 40,
+    quantity: 17,
+  },
+  {
+    id: "WSH09",
+    url: "https://demo.topsort.com/mimi-all-purpose-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh09-gray_main_1.jpg",
+    name: "Mimi All-Purpose Short",
+    price: 44,
+    quantity: 14,
+  },
+  {
+    id: "WSH08",
+    url: "https://demo.topsort.com/sybil-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh08-purple_main_1.jpg",
+    name: "Sybil Running Short",
+    price: 44,
+    quantity: 20,
+  },
+  {
+    id: "WSH07",
+    url: "https://demo.topsort.com/echo-fit-compression-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh07-black_main_1.jpg",
+    name: "Echo Fit Compression Short",
+    price: 24,
+    quantity: 10,
+  },
+  {
+    id: "WSH06",
+    url: "https://demo.topsort.com/angel-light-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh06-gray_main_1.jpg",
+    name: "Angel Light Running Short",
+    price: 42,
+    quantity: 3,
+  },
+  {
+    id: "WSH05",
+    url: "https://demo.topsort.com/bess-yoga-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh05-blue_main_1.jpg",
+    name: "Bess Yoga Short",
+    price: 28,
+    quantity: 18,
+  },
+  {
+    id: "WSH04",
+    url: "https://demo.topsort.com/artemis-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh04-black_main_1.jpg",
+    name: "Artemis Running Short",
+    price: 45,
+    quantity: 24,
+  },
+  {
+    id: "WSH03",
+    url: "https://demo.topsort.com/gwen-drawstring-bike-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh03-gray_main_2.jpg",
+    name: "Gwen Drawstring Bike Short",
+    price: 50,
+    quantity: 8,
+  },
+  {
+    id: "WSH02",
+    url: "https://demo.topsort.com/maxima-drawstring-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh02-gray_main_1.jpg",
+    name: "Maxima Drawstring Short",
+    price: 28,
+    quantity: 7,
+  },
+  {
+    id: "WSH01",
+    url: "https://demo.topsort.com/fiona-fitness-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/w/s/wsh01-black_main_1.jpg",
+    name: "Fiona Fitness Short",
+    price: 29,
+    quantity: 18,
+  },
+  {
+    id: "MJ12",
+    url: "https://demo.topsort.com/proteus-fitness-jackshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj12-orange_main_1.jpg",
+    name: "Proteus Fitness Jackshirt",
+    price: 45,
+    quantity: 21,
+  },
+  {
+    id: "MJ03",
+    url: "https://demo.topsort.com/montana-wind-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj03-black_main_1.jpg",
+    name: "Montana Wind Jacket",
+    price: 49,
+    quantity: 16,
+  },
+  {
+    id: "MJ06",
+    url: "https://demo.topsort.com/jupiter-all-weather-trainer.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj06-blue_main_1.jpg",
+    name: "Jupiter All-Weather Trainer",
+    price: 56.99,
+    quantity: 3,
+  },
+  {
+    id: "MJ11",
+    url: "https://demo.topsort.com/typhon-performance-fleece-lined-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj11-black_main_1.jpg",
+    name: "Typhon Performance Fleece-lined Jacket",
+    price: 60,
+    quantity: 18,
+  },
+  {
+    id: "MJ10",
+    url: "https://demo.topsort.com/mars-heattech-trade-pullover.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj10-red_main_1.jpg",
+    name: "Mars HeatTech™ Pullover",
+    price: 66,
+    quantity: 13,
+  },
+  {
+    id: "MJ09",
+    url: "https://demo.topsort.com/taurus-elements-shell.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj09-yellow_main_2.jpg",
+    name: "Taurus Elements Shell",
+    price: 65,
+    quantity: 24,
+  },
+  {
+    id: "MJ08",
+    url: "https://demo.topsort.com/lando-gym-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj08-gray_main_1.jpg",
+    name: "Lando Gym Jacket",
+    price: 99,
+    quantity: 25,
+  },
+  {
+    id: "MJ07",
+    url: "https://demo.topsort.com/orion-two-tone-fitted-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj07-red_main_1.jpg",
+    name: "Orion Two-Tone Fitted Jacket",
+    price: 72,
+    quantity: 2,
+  },
+  {
+    id: "MJ04",
+    url: "https://demo.topsort.com/kenobi-trail-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj04-black_main_1.jpg",
+    name: "Kenobi Trail Jacket",
+    price: 47,
+    quantity: 23,
+  },
+  {
+    id: "MJ02",
+    url: "https://demo.topsort.com/hyperion-elements-jacket.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj02-green_main_1.jpg",
+    name: "Hyperion Elements Jacket",
+    price: 51,
+    quantity: 2,
+  },
+  {
+    id: "MJ01",
+    url: "https://demo.topsort.com/beaumont-summit-kit.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/j/mj01-yellow_main_1.jpg",
+    name: "Beaumont Summit Kit",
+    price: 42,
+    quantity: 5,
+  },
+  {
+    id: "MH12",
+    url: "https://demo.topsort.com/ajax-full-zip-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh12-green_main_1.jpg",
+    name: "Ajax Full-Zip Sweatshirt",
+    price: 69,
+    quantity: 21,
+  },
+  {
+    id: "MH11",
+    url: "https://demo.topsort.com/grayson-crewneck-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh11-white_main_1.jpg",
+    name: "Grayson Crewneck Sweatshirt",
+    price: 64,
+    quantity: 8,
+  },
+  {
+    id: "MH10",
+    url: "https://demo.topsort.com/mach-street-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh10-blue_main_1.jpg",
+    name: "Mach Street Sweatshirt",
+    price: 62,
+    quantity: 8,
+  },
+  {
+    id: "MH09",
+    url: "https://demo.topsort.com/abominable-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh09-blue_main_1.jpg",
+    name: "Abominable Hoodie",
+    price: 69,
+    quantity: 11,
+  },
+  {
+    id: "MH08",
+    url: "https://demo.topsort.com/oslo-trek-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh08-brown_main_1.jpg",
+    name: "Oslo Trek Hoodie",
+    price: 42,
+    quantity: 5,
+  },
+  {
+    id: "MH07",
+    url: "https://demo.topsort.com/hero-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh07-gray_main_2.jpg",
+    name: "Hero Hoodie",
+    price: 54,
+    quantity: 19,
+  },
+  {
+    id: "MH06",
+    url: "https://demo.topsort.com/stark-fundamental-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh06-blue_main_1.jpg",
+    name: "Stark Fundamental Hoodie",
+    price: 42,
+    quantity: 1,
+  },
+  {
+    id: "MH05",
+    url: "https://demo.topsort.com/hollister-backyard-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh05-white_main_1.jpg",
+    name: "Hollister Backyard Sweatshirt",
+    price: 52,
+    quantity: 23,
+  },
+  {
+    id: "MH04",
+    url: "https://demo.topsort.com/frankie-sweatshirt.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh04-green_main_1.jpg",
+    name: "Frankie Sweatshirt",
+    price: 60,
+    quantity: 16,
+  },
+  {
+    id: "MH03",
+    url: "https://demo.topsort.com/bruno-compete-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh03-black_main_1.jpg",
+    name: "Bruno Compete Hoodie",
+    price: 63,
+    quantity: 16,
+  },
+  {
+    id: "MH02",
+    url: "https://demo.topsort.com/teton-pullover-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh02-black_main_1.jpg",
+    name: "Teton Pullover Hoodie",
+    price: 70,
+    quantity: 24,
+  },
+  {
+    id: "MH01",
+    url: "https://demo.topsort.com/chaz-kangeroo-hoodie.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/h/mh01-gray_main_1.jpg",
+    name: "Chaz Kangeroo Hoodie",
+    price: 52,
+    quantity: 25,
+  },
+  {
+    id: "MS08",
+    url: "https://demo.topsort.com/strike-endurance-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms08-black_main_1.jpg",
+    name: "Strike Endurance Tee",
+    price: 39,
+    quantity: 3,
+  },
+  {
+    id: "MS07",
+    url: "https://demo.topsort.com/deion-long-sleeve-evercool-trade-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms07-green_main_1.jpg",
+    name: "Deion Long-Sleeve EverCool™ Tee",
+    price: 39,
+    quantity: 17,
+  },
+  {
+    id: "MS10",
+    url: "https://demo.topsort.com/logan-heattec-reg-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms10-blue_main_1.jpg",
+    name: "Logan HeatTec® Tee",
+    price: 24,
+    quantity: 23,
+  },
+  {
+    id: "MS02",
+    url: "https://demo.topsort.com/ryker-lumatech-trade-tee-v-neck.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms02-gray_main_1.jpg",
+    name: "Ryker LumaTech™ Tee (V-neck)",
+    price: 28,
+    quantity: 1,
+  },
+  {
+    id: "MS01",
+    url: "https://demo.topsort.com/aero-daily-fitness-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms01-blue_main_1.jpg",
+    name: "Aero Daily Fitness Tee",
+    price: 24,
+    quantity: 6,
+  },
+  {
+    id: "MS06",
+    url: "https://demo.topsort.com/zoltan-gym-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms06-blue_main_1.jpg",
+    name: "Zoltan Gym Tee",
+    price: 29,
+    quantity: 16,
+  },
+  {
+    id: "MS03",
+    url: "https://demo.topsort.com/balboa-persistence-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms03-black_main_1.jpg",
+    name: "Balboa Persistence Tee",
+    price: 29,
+    quantity: 6,
+  },
+  {
+    id: "MS12",
+    url: "https://demo.topsort.com/atomic-endurance-running-tee-crew-neck.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms12-red_main_1.jpg",
+    name: "Atomic Endurance Running Tee (Crew-Neck)",
+    price: 29,
+    quantity: 12,
+  },
+  {
+    id: "MS11",
+    url: "https://demo.topsort.com/atomic-endurance-running-tee-v-neck.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms11-green_main_1.jpg",
+    name: "Atomic Endurance Running Tee (V-neck)",
+    price: 28,
+    quantity: 19,
+  },
+  {
+    id: "MS09",
+    url: "https://demo.topsort.com/ryker-lumatech-trade-tee-crew-neck.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms09-blue_main_1.jpg",
+    name: "Ryker LumaTech™ Tee (Crew-neck)",
+    price: 32,
+    quantity: 16,
+  },
+  {
+    id: "MS05",
+    url: "https://demo.topsort.com/helios-evercool-trade-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms05-blue_main_1.jpg",
+    name: "Helios EverCool™ Tee",
+    price: 24,
+    quantity: 21,
+  },
+  {
+    id: "MS04",
+    url: "https://demo.topsort.com/gobi-heattec-reg-tee.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/ms04-orange_main_1.jpg",
+    name: "Gobi HeatTec® Tee",
+    price: 29,
+    quantity: 13,
+  },
+  {
+    id: "MT12",
+    url: "https://demo.topsort.com/cassius-sparring-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt12-blue_main_1.jpg",
+    name: "Cassius Sparring Tank",
+    price: 18,
+    quantity: 11,
+  },
+  {
+    id: "MT11",
+    url: "https://demo.topsort.com/atlas-fitness-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt11-blue_main_1.jpg",
+    name: "Atlas Fitness Tank",
+    price: 18,
+    quantity: 19,
+  },
+  {
+    id: "MT10",
+    url: "https://demo.topsort.com/tiberius-gym-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt10-yellow_main_1.jpg",
+    name: "Tiberius Gym Tank",
+    price: 18,
+    quantity: 13,
+  },
+  {
+    id: "MT09",
+    url: "https://demo.topsort.com/sinbad-fitness-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt09-blue_main_1.jpg",
+    name: "Sinbad Fitness Tank",
+    price: 29,
+    quantity: 4,
+  },
+  {
+    id: "MT08",
+    url: "https://demo.topsort.com/sparta-gym-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt08-green_main_1.jpg",
+    name: "Sparta Gym Tank",
+    price: 29,
+    quantity: 3,
+  },
+  {
+    id: "MT07",
+    url: "https://demo.topsort.com/argus-all-weather-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt07-gray_main_1.jpg",
+    name: "Argus All-Weather Tank",
+    price: 22,
+    quantity: 15,
+  },
+  {
+    id: "MT06",
+    url: "https://demo.topsort.com/vulcan-weightlifting-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt06-black_main_1.jpg",
+    name: "Vulcan Weightlifting Tank",
+    price: 28,
+    quantity: 11,
+  },
+  {
+    id: "MT05",
+    url: "https://demo.topsort.com/rocco-gym-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt05-blue_main_1.jpg",
+    name: "Rocco Gym Tank",
+    price: 24,
+    quantity: 22,
+  },
+  {
+    id: "MT04",
+    url: "https://demo.topsort.com/helios-endurance-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt04-blue_main_1.jpg",
+    name: "Helios Endurance Tank",
+    price: 32,
+    quantity: 2,
+  },
+  {
+    id: "MT03",
+    url: "https://demo.topsort.com/primo-endurance-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt03-red_main_1.jpg",
+    name: "Primo Endurance Tank",
+    price: 29,
+    quantity: 21,
+  },
+  {
+    id: "MT02",
+    url: "https://demo.topsort.com/tristan-endurance-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt02-white_main_2.jpg",
+    name: "Tristan Endurance Tank",
+    price: 29,
+    quantity: 15,
+  },
+  {
+    id: "MT01",
+    url: "https://demo.topsort.com/erikssen-cooltech-trade-fitness-tank.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/t/mt01-red_main_1.jpg",
+    name: "Erikssen CoolTech™ Fitness Tank",
+    price: 29,
+    quantity: 10,
+  },
+  {
+    id: "MP12",
+    url: "https://demo.topsort.com/cronus-yoga-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp12-black_main_1.jpg",
+    name: "Cronus Yoga Pant",
+    price: 48,
+    quantity: 3,
+  },
+  {
+    id: "MP11",
+    url: "https://demo.topsort.com/aether-gym-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp11-brown_main_1.jpg",
+    name: "Aether Gym Pant",
+    price: 74,
+    quantity: 16,
+  },
+  {
+    id: "MP10",
+    url: "https://demo.topsort.com/orestes-yoga-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp10-black_main_2.jpg",
+    name: "Orestes Yoga Pant",
+    price: 66,
+    quantity: 3,
+  },
+  {
+    id: "MP09",
+    url: "https://demo.topsort.com/livingston-all-purpose-tight.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp09-blue_main_1.jpg",
+    name: "Livingston All-Purpose Tight",
+    price: 75,
+    quantity: 18,
+  },
+  {
+    id: "MP08",
+    url: "https://demo.topsort.com/zeppelin-yoga-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp08-green_main_1.jpg",
+    name: "Zeppelin Yoga Pant",
+    price: 82,
+    quantity: 4,
+  },
+  {
+    id: "MP07",
+    url: "https://demo.topsort.com/thorpe-track-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp07-blue_main_1.jpg",
+    name: "Thorpe Track Pant",
+    price: 68,
+    quantity: 12,
+  },
+  {
+    id: "MP06",
+    url: "https://demo.topsort.com/mithra-warmup-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp06-gray_main_1.jpg",
+    name: "Mithra Warmup Pant",
+    price: 28,
+    quantity: 2,
+  },
+  {
+    id: "MP05",
+    url: "https://demo.topsort.com/kratos-gym-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp05-blue_main_1.jpg",
+    name: "Kratos Gym Pant",
+    price: 57,
+    quantity: 25,
+  },
+  {
+    id: "MP04",
+    url: "https://demo.topsort.com/supernova-sport-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp04-gray_main_1.jpg",
+    name: "Supernova Sport Pant",
+    price: 45,
+    quantity: 20,
+  },
+  {
+    id: "MP03",
+    url: "https://demo.topsort.com/geo-insulated-jogging-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp03-black_main_1.jpg",
+    name: "Geo Insulated Jogging Pant",
+    price: 51,
+    quantity: 4,
+  },
+  {
+    id: "MP02",
+    url: "https://demo.topsort.com/viktor-lumatech-trade-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp02-gray_main_2.jpg",
+    name: "Viktor LumaTech™ Pant",
+    price: 46,
+    quantity: 8,
+  },
+  {
+    id: "MP01",
+    url: "https://demo.topsort.com/caesar-warm-up-pant.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/p/mp01-gray_main_1.jpg",
+    name: "Caesar Warm-Up Pant",
+    price: 35,
+    quantity: 8,
+  },
+  {
+    id: "MSH12",
+    url: "https://demo.topsort.com/pierce-gym-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh12-red_main_1.jpg",
+    name: "Pierce Gym Short",
+    price: 27,
+    quantity: 8,
+  },
+  {
+    id: "MSH11",
+    url: "https://demo.topsort.com/arcadio-gym-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh11-blue_main_1.jpg",
+    name: "Arcadio Gym Short",
+    price: 20,
+    quantity: 1,
+  },
+  {
+    id: "MSH10",
+    url: "https://demo.topsort.com/sol-active-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh10-blue_main_1.jpg",
+    name: "Sol Active Short",
+    price: 32,
+    quantity: 8,
+  },
+  {
+    id: "MSH09",
+    url: "https://demo.topsort.com/troy-yoga-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh09-blue_main_1.jpg",
+    name: "Troy Yoga Short",
+    price: 24,
+    quantity: 17,
+  },
+  {
+    id: "MSH08",
+    url: "https://demo.topsort.com/orestes-fitness-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh08-black_main_1.jpg",
+    name: "Orestes Fitness Short",
+    price: 35,
+    quantity: 20,
+  },
+  {
+    id: "MSH07",
+    url: "https://demo.topsort.com/rapha-sports-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh07-black_main_1.jpg",
+    name: "Rapha Sports Short",
+    price: 35,
+    quantity: 18,
+  },
+  {
+    id: "MSH06",
+    url: "https://demo.topsort.com/lono-yoga-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh06-gray_main_2.jpg",
+    name: "Lono Yoga Short",
+    price: 32,
+    quantity: 22,
+  },
+  {
+    id: "MSH05",
+    url: "https://demo.topsort.com/hawkeye-yoga-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh05-gray_main_1.jpg",
+    name: "Hawkeye Yoga Short",
+    price: 29,
+    quantity: 11,
+  },
+  {
+    id: "MSH04",
+    url: "https://demo.topsort.com/torque-power-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh04-gray_main_1.jpg",
+    name: "Torque Power Short",
+    price: 32.5,
+    quantity: 7,
+  },
+  {
+    id: "MSH03",
+    url: "https://demo.topsort.com/meteor-workout-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh03-blue_main_1.jpg",
+    name: "Meteor Workout Short",
+    price: 32.5,
+    quantity: 7,
+  },
+  {
+    id: "MSH02",
+    url: "https://demo.topsort.com/apollo-running-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh02-black_main_1.jpg",
+    name: "Apollo Running Short",
+    price: 32.5,
+    quantity: 12,
+  },
+  {
+    id: "MSH01",
+    url: "https://demo.topsort.com/cobalt-cooltech-trade-fitness-short.html",
+    imgUrl:
+      "https://demo.topsort.com/media/catalog/product/cache/aa9aafb6a4706fae003d9ec8034d6da2/m/s/msh01-blue_main_1.jpg",
+    name: "Cobalt CoolTech™ Fitness Short",
+    price: 44,
+    quantity: 22,
+  },
+];

--- a/src/app.css
+++ b/src/app.css
@@ -43,6 +43,8 @@ hr.ts-hr {
 }
 
 .ts-product-image {
+  background-color: #fff;
+  object-fit: contain;
   box-sizing: border-box;
   border: 1px solid #f0f0f0;
   border-radius: 0.75rem;


### PR DESCRIPTION
This further improves the demo with search functionality and allows the display of Luma products controlled by a variable.

<img width="1022" alt="Screen Shot 2022-10-07 at 1 28 55 PM" src="https://user-images.githubusercontent.com/23301657/194647652-3440c276-0e5b-4a4f-b9a0-da06b3395eb3.png">


<img width="1025" alt="Screen Shot 2022-10-07 at 1 28 25 PM" src="https://user-images.githubusercontent.com/23301657/194647610-df4071c5-e5a1-4ed5-bdec-4e528cc50034.png">
