### PR TITLE
feat(demo): stub API responses for demo

### DIFF
--- a/src/components/CampaignCreation/Confirm.tsx
+++ b/src/components/CampaignCreation/Confirm.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@components/Icon";
 import { Select } from "@components/Select";
 import { CampaignBudget, CampaignSummary } from "@components/common";
 import { useProductPromotion } from "@context";
-import * as services from "@services/central-services";
+import * as services from "@services/central-services/mock";
 import { logger } from "@utils/logger";
 import { h, FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";

--- a/src/components/CampaignCreation/PaymentForm.tsx
+++ b/src/components/CampaignCreation/PaymentForm.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { useProductPromotion } from "@context";
-import * as services from "@services/central-services";
+import * as services from "@services/central-services/mock";
 import {
   Elements,
   useStripe,

--- a/src/components/CampaignDetails/index.tsx
+++ b/src/components/CampaignDetails/index.tsx
@@ -3,7 +3,7 @@ import { BackButton } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { ModalContent, ModalHeading } from "@components/Modal";
 import { useProductPromotion } from "@context";
-import * as services from "@services/central-services";
+import * as services from "@services/central-services/mock";
 import { h, FunctionalComponent, Fragment } from "preact";
 import { useEffect, useState } from "preact/hooks";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { Modal } from "@components/Modal";
 import Portal from "@components/Portal";
 import { defaultPromoteTargetClassName } from "@constants";
 import { ProductPromotionContext, useProductPromotion } from "@context";
-import * as services from "@services/central-services";
+import * as services from "@services/central-services/mock";
 import { initialState, reducer, State } from "@state";
 import { CustomText, RequestStatus, Style } from "@types";
 import {

--- a/src/services/central-services/mock.ts
+++ b/src/services/central-services/mock.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type {
+  CampaignIdsByProductId,
+  ValidateVendor,
+  PaymentMethod,
+  Campaign,
+} from "@api/types";
+import { PaymentMethod as StripePaymentMethod } from "@stripe/stripe-js";
+
+function uuidv4() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+    (
+      c ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+    ).toString(16)
+  );
+}
+
+const testCampaignId = uuidv4();
+
+const testCampaignsById: Record<string, Campaign> = {
+  [testCampaignId]: {
+    campaignId: testCampaignId,
+    name: "Helena Hooded Fleece Campaign",
+    budget: {
+      amount: 200,
+      type: "daily",
+    },
+    startDate: "2019-08-22T14:15:22Z",
+    endDate: "2019-08-24T14:15:22Z",
+    campaignBehaviorData: {
+      clicks: {
+        total: 24,
+        charged: 24,
+        adSpent: 24,
+      },
+      impressions: {
+        total: 1341,
+        charged: 1341,
+        adSpent: 1341,
+      },
+      purchases: {
+        amount: 19,
+        count: 19,
+        quantity: 19,
+      },
+    },
+  },
+};
+
+function delayedResponse<T>(response: T): Promise<T> {
+  return new Promise((res) => setTimeout(() => res(response), 1000));
+}
+
+export async function validateVendor(
+  apiKey: string,
+  vendorId: string
+): Promise<ValidateVendor> {
+  return delayedResponse({
+    authToken: "auth-token-123",
+  });
+}
+
+export async function getCampaignIdsByProductId(
+  authToken: string,
+  vendorId: string,
+  productIds: string[]
+): Promise<CampaignIdsByProductId> {
+  const response = productIds.reduce((acc, id) => {
+    acc[id] = id === "WH10" ? testCampaignId : null;
+    return acc;
+  }, {} as CampaignIdsByProductId);
+  return delayedResponse(response);
+}
+
+export async function getPaymentMethods(
+  authToken: string
+): Promise<PaymentMethod[]> {
+  return delayedResponse([]);
+}
+
+export async function createPaymentMethod(
+  authToken: string,
+  paymentMethod: StripePaymentMethod
+): Promise<null> {
+  return delayedResponse(null);
+}
+
+export async function createCampaign(
+  authToken: string,
+  vendorId: string,
+  {
+    productId,
+    name,
+    dailyBudget,
+    startDate,
+    endDate,
+    paymentMethod,
+    currencyCode,
+  }: {
+    productId: string;
+    name: string;
+    dailyBudget: number;
+    startDate: string;
+    endDate: string;
+    paymentMethod: PaymentMethod;
+    currencyCode: string;
+  }
+): Promise<Campaign> {
+  const response = await delayedResponse({
+    name,
+    campaignId: uuidv4(),
+    budget: {
+      type: "daily" as Campaign["budget"]["type"],
+      amount: dailyBudget * 100,
+    },
+    startDate,
+    endDate,
+  });
+  return {
+    ...response,
+    campaignBehaviorData: {
+      clicks: {
+        total: 0,
+        charged: 0,
+        adSpent: 0,
+      },
+      impressions: {
+        total: 0,
+        charged: 0,
+        adSpent: 0,
+      },
+      purchases: {
+        amount: 0,
+        count: 0,
+        quantity: 0,
+      },
+    },
+  };
+}
+
+export async function getCampaign(
+  authToken: string,
+  vendorId: string,
+  campaignId: string
+): Promise<Campaign> {
+  return delayedResponse(testCampaignsById[campaignId]);
+}


### PR DESCRIPTION
This creates a mock central services with stubbed responses after a 1s delay to simulate API load time. We will improve this in the future so that we don't need to import the mock file directly and instead control it with an env var perhaps.