### PR TITLE
fix(campaign ended): close modal with button

### DIFF
--- a/src/components/CampaignDetails/Ended.tsx
+++ b/src/components/CampaignDetails/Ended.tsx
@@ -1,6 +1,7 @@
 import { Campaign } from "@api/types";
 import { Button } from "@components/Button";
 import { CampaignSummary } from "@components/common";
+import { useProductPromotion } from "@context";
 import { h, FunctionComponent } from "preact";
 
 import { Metrics } from "./Metrics";
@@ -8,12 +9,16 @@ import { Metrics } from "./Metrics";
 export const Ended: FunctionComponent<{ campaign: Campaign }> = ({
   campaign,
 }) => {
+  const { dispatch } = useProductPromotion();
   return (
     <div className="ts-space-y-5">
       <CampaignSummary />
       <Metrics title="Final Metrics" campaign={campaign} />
-      {/* TODO(samet): close the modal */}
-      <Button fullWidth variant="contained">
+      <Button
+        fullWidth
+        variant="contained"
+        onClick={() => dispatch({ type: "modal close button clicked" })}
+      >
         Close
       </Button>
     </div>


### PR DESCRIPTION
Clicking this button now closes the modal:

<img width="446" alt="Screen Shot 2022-10-07 at 4 54 03 PM" src="https://user-images.githubusercontent.com/23301657/194676429-29897fbd-09e9-4d2e-bc6d-2d0ea2640bc4.png">
