### PR TITLE
fix(build): add mode to demo webpack config

### DIFF
--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -6,6 +6,7 @@ const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
+  mode: "production",
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, "./demo/index.html"),


### PR DESCRIPTION
Mode is a required field and even though it defaults to "production", the script was throwing a warning so better to be explicit.

Before:

<img width="922" alt="Screen Shot 2022-10-07 at 5 13 22 PM" src="https://user-images.githubusercontent.com/23301657/194677475-82031018-8b51-4fda-86f5-d5b9150b3766.png">

After:

<img width="853" alt="Screen Shot 2022-10-07 at 5 13 51 PM" src="https://user-images.githubusercontent.com/23301657/194677490-debcd84d-8020-47d7-a19c-1312b3c9e377.png">
