### PR TITLE
fix(demo): fix demo campaign dates

### DIFF
--- a/demo/loader.js
+++ b/demo/loader.js
@@ -34,7 +34,9 @@ function createProductElement(product) {
   productElement.querySelector(".product-code").innerText = product.id;
   productElement.querySelector(".product-quantity").innerText =
     product.quantity;
-  productElement.querySelector(".product-price").innerText = product.price;
+  productElement.querySelector(
+    ".product-price"
+  ).innerText = `$${product.price}`;
   productElement.querySelector(".product-status").innerText = "Active";
 
   const target = productElement.querySelector(".promote-target-placeholder");
@@ -62,7 +64,7 @@ function getNumberedProducts() {
       id: `product-${i}`,
       imgUrl: `https://picsum.photos/${imgSize}?random=${i}`,
       name: `Product ${i}`,
-      price: `$${i}.99`,
+      price: `${i}.99`,
       quantity: i,
       // to demo NOT putting a promote button on a certain product
       skip: i === 8,

--- a/src/services/central-services/mock.ts
+++ b/src/services/central-services/mock.ts
@@ -32,17 +32,17 @@ const testCampaignsById: Record<string, Campaign> = {
     endDate: "2022-10-24T14:15:22Z",
     campaignBehaviorData: {
       clicks: {
-        total: 24,
-        charged: 24,
-        adSpent: 24,
+        total: 208,
+        charged: 208,
+        adSpent: 208,
       },
       impressions: {
-        total: 1341,
-        charged: 1341,
-        adSpent: 1341,
+        total: 302,
+        charged: 76,
+        adSpent: 109,
       },
       purchases: {
-        amount: 19,
+        amount: 1045,
         count: 19,
         quantity: 19,
       },


### PR DESCRIPTION
This changes the demo campaign start and end date to a more recent date, and the metrics for better demo purposes.

Before:

<img width="422" alt="Screen Shot 2022-10-07 at 6 10 20 PM" src="https://user-images.githubusercontent.com/23301657/194680140-3c110b97-8403-4ba4-adcc-64aa88543af2.png">


After:

<img width="419" alt="Screen Shot 2022-10-07 at 6 10 00 PM" src="https://user-images.githubusercontent.com/23301657/194680130-f1b39100-3675-4798-8dd6-c3a36c119a2d.png">


