### PR TITLE
Fix currency format

### DIFF
--- a/src/components/common/CampaignEstimation.tsx
+++ b/src/components/common/CampaignEstimation.tsx
@@ -31,7 +31,8 @@ export const CampaignEstimation: FunctionalComponent<
       <span className="ts-text-sm ts-font-semimedium">
         With a{" "}
         <span className="ts-font-bold">
-          {dailyBudget} {currencyCode}
+          {/* TODO make it generic */}
+          {dailyBudget.toFixed(2)} {currencyCode}
         </span>{" "}
         <span className="ts-font-bold">{durationDays} days</span> we estimate{" "}
         <span className="ts-text-primary">


### PR DESCRIPTION
The number of digits in the fractional part of the currency is fixed to 2.

![image](https://user-images.githubusercontent.com/32245727/194679427-178fa016-9774-45bf-9c83-825031d7b03e.png)
