### PR TITLE
feat: display modal for multi-product campaign

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -38,6 +38,7 @@ export const campaignPartialSchema = z.object({
 });
 
 export const campaignSchema = campaignPartialSchema.extend({
+  activeBidsCount: z.number().int().min(0),
   campaignBehaviorData: z.object({
     clicks: z.object({
       total: z.number().min(0),

--- a/src/components/CampaignDetails/MultiProduct.tsx
+++ b/src/components/CampaignDetails/MultiProduct.tsx
@@ -1,0 +1,16 @@
+import { Link } from "@components/Link";
+import { CampaignSummary } from "@components/common";
+import { h, FunctionalComponent } from "preact";
+
+export const MultiProduct: FunctionalComponent = () => {
+  return (
+    <div>
+      <CampaignSummary />
+      <span className="ts-multi-product__message ts-text-sm">
+        Please{" "}
+        <Link href="https://app.topsort.com/">log into your dashboard</Link> or
+        contact your admin for more information.
+      </span>
+    </div>
+  );
+};

--- a/src/components/CampaignDetails/index.tsx
+++ b/src/components/CampaignDetails/index.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@components/Icon";
 import { ModalContent, ModalHeading } from "@components/Modal";
 import { useProductPromotion } from "@context";
 import { services } from "@services/central-services";
+import { logger } from "@utils/logger";
 import { h, FunctionalComponent, Fragment } from "preact";
 import { useEffect, useState } from "preact/hooks";
 
@@ -11,6 +12,7 @@ import { Details } from "./Details";
 import { Edit } from "./Edit";
 import { Ended } from "./Ended";
 import { Ending } from "./Ending";
+import { MultiProduct } from "./MultiProduct";
 import "./style.css";
 
 export const CampaignDetails: FunctionalComponent<{
@@ -41,6 +43,7 @@ export const CampaignDetails: FunctionalComponent<{
           payload: { campaign },
         });
       } catch (error) {
+        logger.error(`Failed to get campaign (id="${campaignId}").`, error);
         setHasError(true);
       }
     }
@@ -72,6 +75,13 @@ export const CampaignDetails: FunctionalComponent<{
             )}
           </div>
         ),
+      };
+    }
+
+    if (campaign.activeBidsCount > 1) {
+      return {
+        title: "This product is already under an active campaign",
+        content: <MultiProduct />,
       };
     }
 
@@ -120,6 +130,10 @@ export const CampaignDetails: FunctionalComponent<{
   const contentHeight = (() => {
     if (!campaign) {
       return "8rem";
+    }
+
+    if (campaign.activeBidsCount > 1) {
+      return "fit-content";
     }
 
     switch (step) {

--- a/src/components/CampaignDetails/style.css
+++ b/src/components/CampaignDetails/style.css
@@ -66,9 +66,15 @@
 .ts-edit-form__item > span {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--ts-font-color-70)
+  color: var(--ts-font-color-70);
 }
 
 .ts-edit-form__item > .ts-input-wrapper {
   width: 50%;
+}
+
+.ts-multi-product__message {
+  display: inline-block;
+  line-height: 1.25rem;
+  margin: 1.5rem 0 0.5rem;
 }

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,0 +1,21 @@
+import cx from "classnames";
+import { h, FunctionalComponent, JSX } from "preact";
+
+import "./style.css";
+
+export const Link: FunctionalComponent<JSX.IntrinsicElements["a"]> = ({
+  children,
+  className,
+  ...props
+}) => {
+  return (
+    <a
+      className={cx("ts-link ts-text-primary", className)}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...props}
+    >
+      {children}
+    </a>
+  );
+};

--- a/src/components/Link/style.css
+++ b/src/components/Link/style.css
@@ -1,0 +1,7 @@
+.ts-link {
+  text-decoration: none;
+}
+
+.ts-link:hover {
+  text-decoration: underline;
+}

--- a/src/services/central-services/mock.ts
+++ b/src/services/central-services/mock.ts
@@ -22,6 +22,7 @@ function uuidv4() {
 }
 
 const testCampaignId = uuidv4();
+const testMultiProductCampaignId = uuidv4();
 
 const testCampaignsById: Record<string, Campaign> = {
   [testCampaignId]: {
@@ -33,6 +34,35 @@ const testCampaignsById: Record<string, Campaign> = {
     },
     startDate: "2022-10-06T14:15:22Z",
     endDate: "2022-10-24T14:15:22Z",
+    activeBidsCount: 1,
+    campaignBehaviorData: {
+      clicks: {
+        total: 208,
+        charged: 208,
+        adSpent: 208,
+      },
+      impressions: {
+        total: 302,
+        charged: 76,
+        adSpent: 109,
+      },
+      purchases: {
+        amount: 1045,
+        count: 19,
+        quantity: 19,
+      },
+    },
+  },
+  [testMultiProductCampaignId]: {
+    campaignId: testMultiProductCampaignId,
+    name: "Autumn Pullie",
+    budget: {
+      amount: 200,
+      type: "daily",
+    },
+    startDate: "2022-10-08T14:15:22Z",
+    endDate: "2022-10-22T14:15:22Z",
+    activeBidsCount: 2,
     campaignBehaviorData: {
       clicks: {
         total: 208,
@@ -83,7 +113,13 @@ async function getCampaignIdsByProductId(
   productIds: string[]
 ): Promise<CampaignIdsByProductId> {
   const response = productIds.reduce((acc, id) => {
-    acc[id] = id === "WH10" ? testCampaignId : null;
+    if (id === "WH10") {
+      acc[id] = testCampaignId;
+    } else if (id === "WH03") {
+      acc[id] = testMultiProductCampaignId;
+    } else {
+      acc[id] = null;
+    }
     return acc;
   }, {} as CampaignIdsByProductId);
   return delayedResponse(response);
@@ -130,6 +166,7 @@ async function createCampaign(
   });
   return {
     ...response,
+    activeBidsCount: 1,
     campaignBehaviorData: {
       clicks: {
         total: 0,

--- a/src/services/central-services/services.ts
+++ b/src/services/central-services/services.ts
@@ -96,6 +96,7 @@ const fakeCampaignsById: Record<string, Campaign> = {
     },
     startDate: "2019-08-22T14:15:22Z",
     endDate: "2019-08-24T14:15:22Z",
+    activeBidsCount: 1,
     campaignBehaviorData: {
       clicks: {
         total: 24,
@@ -123,6 +124,7 @@ const fakeCampaignsById: Record<string, Campaign> = {
     },
     startDate: "2019-08-11T14:15:22Z",
     endDate: "2019-08-24T20:54:10Z",
+    activeBidsCount: 1,
     campaignBehaviorData: {
       clicks: {
         total: 42,
@@ -228,6 +230,7 @@ async function createCampaign(
   // filled with zeros for a consistent data format
   return {
     ...response,
+    activeBidsCount: 1,
     campaignBehaviorData: {
       clicks: {
         total: 0,

--- a/src/utils.css
+++ b/src/utils.css
@@ -66,6 +66,10 @@
   color: var(--ts-primary-color);
 }
 
+.ts-text-secondary {
+  color: var(--ts-secondary-color);
+}
+
 .ts-text-100 {
   color: var(--ts-font-color);
 }


### PR DESCRIPTION
The modal currently doesn't support creating multi-product campaigns so
if one of a marketplace's products is part of a multi-product campaign,
it likely means the campaign was created on the Topsort dashboard.

In this case, instead of showing the campaign details flow, a blocking
screen is shown in the modal which directs the user to either log into
their Topsort dashboard or contact their admin.

ADTYPE-552

---

### default:

<img width="424" alt="Screen Shot 2022-10-13 at 9 00 34 AM" src="https://user-images.githubusercontent.com/23301657/195648334-e645682c-9214-408f-b396-f76bc3707499.png">

### hovered:

<img width="419" alt="Screen Shot 2022-10-13 at 9 00 44 AM" src="https://user-images.githubusercontent.com/23301657/195648339-5e135f3e-29cf-4a0d-996f-ada70aca783a.png">

### hovered with different color theme:

<img width="417" alt="Screen Shot 2022-10-13 at 9 01 04 AM" src="https://user-images.githubusercontent.com/23301657/195648343-f7b637db-edcf-4a8a-837f-f7dd6ad192b0.png">
