### PR TITLE
Set placeholder

### DIFF
--- a/src/components/CampaignDetails/Edit.tsx
+++ b/src/components/CampaignDetails/Edit.tsx
@@ -110,7 +110,7 @@ export const Edit: FunctionalComponent<{
     setHasError(false);
 
     const startDate = new Date(campaign.startDate);
-    const newEndDate = new Date();
+    const newEndDate = new Date(startDate);
     newEndDate.setDate(startDate.getDate() + durationDays);
 
     try {


### PR DESCRIPTION
**Jira**: https://topsort.atlassian.net/browse/ADTYPE-556

If the input element is empty, the default value is displayed.

The default "duration" is 3 (days) for the following example. If the content is deleted, "3" is displayed as placeholder. The same is also true for "daily budget"

![image](https://user-images.githubusercontent.com/32245727/195459036-6badc5a3-541c-4508-a948-ff12a7bba492.png)
