### PR TITLE
fix: payment method schema

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -19,15 +19,22 @@ export const campaignIdsByProductIdSchema = z.record(
   z.string().uuid().nullable()
 );
 
+const cardDataSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal("card"),
+  brand: z.string().min(1),
+  last4: z.string().length(4),
+});
+
+const topsortBalanceDataSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal("balance"),
+});
+
 export const paymentMethodSchema = z.object({
   id: z.string().min(1),
   provider: z.string().min(1),
-  data: z.object({
-    id: z.string().min(1),
-    type: z.string().min(1),
-    brand: z.string().min(1),
-    last4: z.string().length(4),
-  }),
+  data: z.union([cardDataSchema, topsortBalanceDataSchema]),
 });
 
 export const paymentMethodsSchema = z.object({

--- a/src/components/CampaignCreation/Confirm.tsx
+++ b/src/components/CampaignCreation/Confirm.tsx
@@ -14,16 +14,20 @@ import { PaymentMethodIcon } from "./utils";
 const FormattedPaymentMethod: FunctionalComponent<{
   paymentMethod: PaymentMethod;
 }> = ({ paymentMethod }) => {
-  if (paymentMethod.data.type !== "card") {
-    return <span>payment method of type "{paymentMethod.data.type}"</span>;
+  if (paymentMethod.data.type === "card") {
+    return (
+      <div className="ts-payment-method ts-space-x-2">
+        <PaymentMethodIcon paymentMethod={paymentMethod} />
+        <span>**** **** **** {paymentMethod.data.last4}</span>
+      </div>
+    );
   }
 
-  return (
-    <div className="ts-payment-method ts-space-x-2">
-      <PaymentMethodIcon paymentMethod={paymentMethod} />
-      <span>**** **** **** {paymentMethod.data.last4}</span>
-    </div>
-  );
+  if (paymentMethod.data.type === "balance") {
+    return <span>Topsort Balance</span>;
+  }
+
+  return <span>Unknown payment method</span>;
 };
 
 export const Confirm: FunctionalComponent = () => {
@@ -113,7 +117,9 @@ export const Confirm: FunctionalComponent = () => {
             value={paymentMethods.find(
               (paymentMethod) => paymentMethod.id === selectedPaymentMethodId
             )}
-            options={paymentMethods}
+            options={paymentMethods.filter(
+              (paymentMethod) => paymentMethod.data.type === "card"
+            )}
             selectRenderer={(selectedOption) =>
               selectedOption ? (
                 <FormattedPaymentMethod paymentMethod={selectedOption} />

--- a/src/components/CampaignCreation/utils.tsx
+++ b/src/components/CampaignCreation/utils.tsx
@@ -5,6 +5,11 @@ import { h, FunctionalComponent } from "preact";
 export const PaymentMethodIcon: FunctionalComponent<{
   paymentMethod: PaymentMethod;
 }> = ({ paymentMethod }) => {
+  if (paymentMethod.data.type === "balance") {
+    // TODO(christopherbot) Topsort logo
+    return null;
+  }
+
   switch (paymentMethod.data.brand) {
     case "visa":
       return <Icon name="visa" viewBox="71.75 85 72.75 45.96" />;

--- a/src/utils/payment.ts
+++ b/src/utils/payment.ts
@@ -19,7 +19,7 @@ export const getStripe = () => {
 export const formatPaymentMethod = (
   paymentMethod: StripePaymentMethod
 ): PaymentMethod => {
-  if (paymentMethod.card) {
+  if (paymentMethod.type === "card" && paymentMethod.card) {
     return {
       id: paymentMethod.id,
       provider: "stripe",


### PR DESCRIPTION
This adds the Topsort balance to the payment method response schema but
does not show it as an option since it is not ready to be used yet.

### Previously:

<img width="895" alt="Screen Shot 2022-10-17 at 4 18 42 PM" src="https://user-images.githubusercontent.com/23301657/196301131-a81aa80f-0ec1-4240-b33d-94673da1146d.png">


### What it will look like once Topsort balance is ready:

<img width="403" alt="Screen Shot 2022-10-17 at 4 13 50 PM" src="https://user-images.githubusercontent.com/23301657/196301093-833b1bd8-249c-48f4-bd75-a7553fcc6700.png">

### What it looks like now:

<img width="375" alt="Screen Shot 2022-10-17 at 4 21 50 PM" src="https://user-images.githubusercontent.com/23301657/196301463-b1bf59d8-87af-4941-902c-eb86df67ea49.png">
