### PR TITLE
Stripe element's color

### DIFF
--- a/src/components/CampaignCreation/PaymentForm.tsx
+++ b/src/components/CampaignCreation/PaymentForm.tsx
@@ -70,7 +70,7 @@ const StripePaymentForm = () => {
         fontSmoothing: "antialiased",
         fontSize: "1rem",
         "::placeholder": {
-          color: style.getPropertyValue("--ts-font-color"),
+          color: style.getPropertyValue("--ts-font-color-60"),
         },
       },
       invalid: {


### PR DESCRIPTION
This PR sets the Stripe input's font color, placeholder color, and invalid color. They were hardcoded previously. 

<img width="386" alt="image" src="https://user-images.githubusercontent.com/32245727/196532771-ebe04159-42a9-43dc-a4ff-414799180a55.png">