### PR TITLE
Fix Stripe font size

### DIFF
--- a/src/components/CampaignCreation/PaymentForm.tsx
+++ b/src/components/CampaignCreation/PaymentForm.tsx
@@ -16,6 +16,7 @@ import {
   StripeCardNumberElement,
   StripeCardNumberElementChangeEvent,
 } from "@stripe/stripe-js";
+import { remToPx } from "@utils/css-unit-converter";
 import { formatPaymentMethod, getStripe } from "@utils/payment";
 import cx from "classnames";
 import { Fragment, h, JSX } from "preact";
@@ -68,7 +69,7 @@ const StripePaymentForm = () => {
       base: {
         color: style.getPropertyValue("--ts-font-color"),
         fontSmoothing: "antialiased",
-        fontSize: "1rem",
+        fontSize: `${remToPx("1rem")}px`,
         "::placeholder": {
           color: style.getPropertyValue("--ts-font-color-60"),
         },


### PR DESCRIPTION
Passing relative css units to the Stripe elements is not recommended.

<img width="781" alt="image" src="https://user-images.githubusercontent.com/32245727/196967887-1524af8a-3822-4ba4-88a2-6fbb2d617470.png">

We don't want to pass `px` values directly. Then, I used `remToPx` to calculate the `px` value of `1rem`.