### PR TITLE
chore: update package-lock.json after last release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@topsort/building-blocks",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@topsort/building-blocks",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.1",


### PR DESCRIPTION
This change was made by running npm install and was not checked in after the last version bump in dbece25227bef94a135ab4a58c753df51ff34074.