### PR TITLE
chore: remove calls to payment service

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -7,8 +7,6 @@ export const paths = {
     `${CENTRAL_SERVICES_BASE_URL}/modal-service/vendors/marketplace-details`,
   defaultBudget: (vendorId: string) =>
     `${CENTRAL_SERVICES_BASE_URL}/modal-service/vendors/${vendorId}/default-budget`,
-  paymentMethods: () =>
-    `${CENTRAL_SERVICES_BASE_URL}/payment-service/payment_methods`,
   products: (vendorId: string) =>
     `${CENTRAL_SERVICES_BASE_URL}/modal-service/vendors/${vendorId}/products`,
   validate: (vendorId: string) => `${AUTH_BASE_URL}/auth/vendors/${vendorId}`,

--- a/src/components/CampaignCreation/PaymentForm.tsx
+++ b/src/components/CampaignCreation/PaymentForm.tsx
@@ -139,7 +139,7 @@ const StripePaymentForm = () => {
     setErrorCodesByType(initialErrorCodesByType);
 
     try {
-      await services.createPaymentMethod(authToken, paymentMethod);
+      // TODO: save payments method in billing API
       dispatch({
         type: "payment method saved",
         payload: {

--- a/src/components/CampaignCreation/index.tsx
+++ b/src/components/CampaignCreation/index.tsx
@@ -27,9 +27,8 @@ export const CampaignCreation: FunctionalComponent = () => {
       try {
         if (paymentMethods.length > 0) return;
 
-        const fetchedPaymentMethods = await services.getPaymentMethods(
-          authToken
-        );
+        // TODO: get payments method from billing API
+        const fetchedPaymentMethods: any[] = [];
 
         dispatch({
           type: "payment methods received",

--- a/src/services/central-services/services.ts
+++ b/src/services/central-services/services.ts
@@ -9,7 +9,6 @@ import type {
   PartialCampaign,
   MarketplaceDetails,
 } from "@api/types";
-import { PaymentMethod as StripePaymentMethod } from "@stripe/stripe-js";
 
 import type { Services } from "./types";
 
@@ -45,39 +44,6 @@ async function getDefaultBudgetAndCpc(
       headers: getHeaders(authToken),
     }
   );
-}
-
-async function getPaymentMethods(authToken: string): Promise<PaymentMethod[]> {
-  const { methods } = await api(
-    schemas.paymentMethodsSchema,
-    paths.paymentMethods(),
-    {
-      method: "GET",
-      headers: getHeaders(authToken),
-    }
-  );
-
-  return methods;
-}
-
-async function createPaymentMethod(
-  authToken: string,
-  paymentMethod: StripePaymentMethod
-): Promise<null> {
-  return await api(schemas.nullSchema, paths.paymentMethods(), {
-    method: "POST",
-    headers: getHeaders(authToken),
-    body: JSON.stringify({
-      data: {
-        id: paymentMethod.id,
-        provider: "stripe",
-        data: {
-          id: paymentMethod.id,
-          type: paymentMethod.type,
-        },
-      },
-    }),
-  });
 }
 
 async function getCampaignIdsByProductId(
@@ -332,8 +298,6 @@ async function endCampaign(
 export const services: Services = {
   getMarketplaceDetails,
   getDefaultBudgetAndCpc,
-  getPaymentMethods,
-  createPaymentMethod,
   getCampaignIdsByProductId,
   getCampaign,
   createCampaign,


### PR DESCRIPTION
As exaplained in https://docs.google.com/document/d/1QUTdG1V4uHu5Ov8YIMRd9vJB62RmtsJodB5HJGXmftw/edit#, we have a bunch of billing related code that's incomplete or unused.

In particular the payment-service was only used by building blocks, however that was currently broken as it was launching a CORS error.

Furthermore, we don't really know how this interact with the legacy billing service we have, since it creates payment entries and configuration that's not replicated to the engine. meaning that it won't appear on the manager, and probably won't even considered at the moment of paying out to customers.