### PR TITLE
feat: Use reporting service instead of campaign behavior summary

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -19,4 +19,6 @@ export const paths = {
     `${centralServicesUrl}/modal-service/vendors/${vendorId}/products`,
   validate: (authUrl: string, vendorId: string) =>
     `${authUrl}/auth/vendors/${vendorId}`,
+  campaignReport: (centralServicesUrl: string, campaignId: string) =>
+    `${centralServicesUrl}/reporting-modal-service/campaigns/${campaignId}`,
 };

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -21,11 +21,6 @@ export const campaignIdsByProductIdSchema = z.record(
   z.string().uuid().nullable()
 );
 
-export const scrollResponse = z.object({
-  hasMore: z.boolean(),
-  nextPage: z.string().min(1).nullable(),
-});
-
 export const reportingApiModels = (function () {
   const events = z.object({
     total: z.bigint(),

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -50,59 +50,11 @@ export const reportingApiModels = (function () {
       lost: z.number(),
     }),
   });
-  const dailyReportData = reportData.extend({
-    date: z.date(),
-  });
-  const dailyReportResponse = scrollResponse.extend({
-    reports: z.array(dailyReportData),
-  });
-  const baseKPIs = z.object({
-    adSpend: z.number().gte(0),
-    cpc: z.number().gte(0.0),
-    ctr: z.number().gte(0.0),
-    conversionRate: z.number().gte(0.0),
-    impressions: z.number().gte(0),
-    chargedImpressions: z.number().gte(0),
-    clicks: z.number().gte(0),
-    chargedClicks: z.number().gte(0),
-    purchaseCount: z.number().gte(0),
-    purchaseRevenue: z.number().gte(0.0),
-    roas: z.number().gte(0.0),
-  });
-  const marketplaceKPIs = baseKPIs.extend({
-    activeVendors: z.number().gte(0),
-  });
-  const reportingDimensions = z.enum([
-    "impressions",
-    "charged_impressions",
-    "clicks",
-    "charged_clicks",
-    "purchases",
-    "purchase_value",
-    "adSpend",
-    "cpc",
-    "ctr",
-    "conversion_rate",
-    "roas",
-    "vendor_id",
-    "vendor_name",
-    "timegroup",
-    "campaign_name",
-    "campaign_id",
-    "campaign_status",
-    "campaign_ad_format",
-  ]);
-
   return {
     events,
     purchases,
     reportData,
     reportDataWithAuctions,
-    dailyReportData,
-    dailyReportResponse,
-    baseKPIs,
-    marketplaceKPIs,
-    reportingDimensions,
   };
 })();
 

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -21,23 +21,90 @@ export const campaignIdsByProductIdSchema = z.record(
   z.string().uuid().nullable()
 );
 
-const campaignBehaviorData = z.object({
-  clicks: z.object({
-    total: z.number().min(0),
-    charged: z.number().min(0),
-    adSpent: z.number().min(0),
-  }),
-  impressions: z.object({
-    total: z.number().min(0),
-    charged: z.number().min(0),
-    adSpent: z.number().min(0),
-  }),
-  purchases: z.object({
-    amount: z.number().min(0),
-    count: z.number().min(0),
-    quantity: z.number().min(0),
-  }),
+export const scrollResponse = z.object({
+  hasMore: z.boolean(),
+  nextPage: z.string().min(1).nullable(),
 });
+
+export const reportingApiModels = (function () {
+  const events = z.object({
+    total: z.bigint(),
+    charged: z.bigint(),
+    adSpent: z.bigint(),
+  });
+  const purchases = z.object({
+    amount: z.bigint(),
+    count: z.bigint(),
+    quantity: z.bigint(),
+    countByProduct: z.record(z.string(), z.bigint()),
+  });
+  const reportData = z.object({
+    impressions: events,
+    clicks: events,
+    purchases,
+  });
+  const reportDataWithAuctions = reportData.extend({
+    auctions: z.object({
+      percentageWon: z.number(),
+      won: z.number(),
+      lost: z.number(),
+    }),
+  });
+  const dailyReportData = reportData.extend({
+    date: z.date(),
+  });
+  const dailyReportResponse = scrollResponse.extend({
+    reports: z.array(dailyReportData),
+  });
+  const baseKPIs = z.object({
+    adSpend: z.number().gte(0),
+    cpc: z.number().gte(0.0),
+    ctr: z.number().gte(0.0),
+    conversionRate: z.number().gte(0.0),
+    impressions: z.number().gte(0),
+    chargedImpressions: z.number().gte(0),
+    clicks: z.number().gte(0),
+    chargedClicks: z.number().gte(0),
+    purchaseCount: z.number().gte(0),
+    purchaseRevenue: z.number().gte(0.0),
+    roas: z.number().gte(0.0),
+  });
+  const marketplaceKPIs = baseKPIs.extend({
+    activeVendors: z.number().gte(0),
+  });
+  const reportingDimensions = z.enum([
+    "impressions",
+    "charged_impressions",
+    "clicks",
+    "charged_clicks",
+    "purchases",
+    "purchase_value",
+    "adSpend",
+    "cpc",
+    "ctr",
+    "conversion_rate",
+    "roas",
+    "vendor_id",
+    "vendor_name",
+    "timegroup",
+    "campaign_name",
+    "campaign_id",
+    "campaign_status",
+    "campaign_ad_format",
+  ]);
+
+  return {
+    events,
+    purchases,
+    reportData,
+    reportDataWithAuctions,
+    dailyReportData,
+    dailyReportResponse,
+    baseKPIs,
+    marketplaceKPIs,
+    reportingDimensions,
+  };
+})();
 
 export const campaignBaseSchema = z.object({
   campaignId: z.string().uuid(),
@@ -50,17 +117,13 @@ export const campaignBaseSchema = z.object({
   endDate: z.string(),
 });
 
-export const campaignPartialSchema = campaignBaseSchema.extend({
-  campaignBehaviorData,
-});
-
-export const campaignSchema = campaignPartialSchema.extend({
+export const campaignSchema = campaignBaseSchema.extend({
   activeBidsCount: z.number().int().min(0).optional(),
 });
 
 export const checkVendorCampaignSchema = z.object({
   exists: z.boolean(),
-  campaign: campaignPartialSchema.nullable(),
+  campaign: campaignBaseSchema.nullable(),
 });
 
 export const validationSchema = z.object({

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,3 +25,5 @@ export type ValidationResponse = z.infer<typeof schemas.validationSchema>;
 export type ReportDataWithAuctions = z.infer<
   typeof schemas.reportingApiModels.reportDataWithAuctions
 >;
+
+export type CampaignWithReport = Campaign & { report: ReportDataWithAuctions };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,7 +13,6 @@ export type CampaignIdsByProductId = z.infer<
 >;
 
 export type BaseCampaign = z.infer<typeof schemas.campaignBaseSchema>;
-export type PartialCampaign = z.infer<typeof schemas.campaignPartialSchema>;
 
 export type Campaign = z.infer<typeof schemas.campaignSchema>;
 
@@ -22,3 +21,7 @@ export type CheckVendorCampaign = z.infer<
 >;
 
 export type ValidationResponse = z.infer<typeof schemas.validationSchema>;
+
+export type ReportDataWithAuctions = z.infer<
+  typeof schemas.reportingApiModels.reportDataWithAuctions
+>;

--- a/src/components/CampaignCreation/Confirm.tsx
+++ b/src/components/CampaignCreation/Confirm.tsx
@@ -49,9 +49,15 @@ export const Confirm: FunctionalComponent = () => {
         }
       );
 
+      const report = await services.getCampaignReport(
+        centralServicesUrl,
+        authToken,
+        campaign.campaignId
+      );
+
       dispatch({
         type: "product campaign launched",
-        payload: { campaign, productId },
+        payload: { campaign, report, productId },
       });
     };
 

--- a/src/components/CampaignDetails/CampaignEnded.tsx
+++ b/src/components/CampaignDetails/CampaignEnded.tsx
@@ -1,4 +1,4 @@
-import { Campaign } from "@api/types";
+import { ReportDataWithAuctions } from "@api/types";
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { ModalContent, ModalHeading } from "@components/Modal";
@@ -8,9 +8,9 @@ import { FunctionComponent, Fragment } from "preact";
 
 import { Metrics } from "./Metrics";
 
-export const CampaignEnded: FunctionComponent<{ campaign: Campaign }> = ({
-  campaign,
-}) => {
+export const CampaignEnded: FunctionComponent<{
+  campaignReport: ReportDataWithAuctions;
+}> = ({ campaignReport }) => {
   const { dispatch } = usePromotionContext();
   const title = (
     <Fragment>
@@ -24,7 +24,7 @@ export const CampaignEnded: FunctionComponent<{ campaign: Campaign }> = ({
       <ModalContent height="fit-content">
         <div className="ts-space-y-5">
           <CampaignSummary />
-          <Metrics title="Final Metrics" campaign={campaign} />
+          <Metrics title="Final Metrics" campaignReport={campaignReport} />
           <Button
             fullWidth
             variant="contained"

--- a/src/components/CampaignDetails/Details.tsx
+++ b/src/components/CampaignDetails/Details.tsx
@@ -1,4 +1,4 @@
-import { Campaign, ReportDataWithAuctions } from "@api/types";
+import { CampaignWithReport } from "@api/types";
 import { CampaignBudget, CampaignSummary } from "@components/common";
 import { MS_PER_DAY } from "@constants";
 import { usePromotionContext } from "@context";
@@ -8,9 +8,8 @@ import { useMemo } from "preact/hooks";
 import { Metrics } from "./Metrics";
 
 export const Details: FunctionalComponent<{
-  campaign: Campaign;
-  campaignReport: ReportDataWithAuctions;
-}> = ({ campaign, campaignReport }) => {
+  campaign: CampaignWithReport;
+}> = ({ campaign }) => {
   const { dispatch } = usePromotionContext();
   const days = useMemo(() => {
     const end = new Date(campaign.endDate);
@@ -33,7 +32,7 @@ export const Details: FunctionalComponent<{
         onEdit={() => dispatch({ type: "edit campaign button clicked" })}
       />
       <hr className="ts-hr" />
-      <Metrics title="Metrics" campaignReport={campaignReport} />
+      <Metrics title="Metrics" campaignReport={campaign.report} />
     </div>
   );
 };

--- a/src/components/CampaignDetails/Details.tsx
+++ b/src/components/CampaignDetails/Details.tsx
@@ -1,4 +1,4 @@
-import { Campaign } from "@api/types";
+import { Campaign, ReportDataWithAuctions } from "@api/types";
 import { CampaignBudget, CampaignSummary } from "@components/common";
 import { MS_PER_DAY } from "@constants";
 import { usePromotionContext } from "@context";
@@ -9,7 +9,8 @@ import { Metrics } from "./Metrics";
 
 export const Details: FunctionalComponent<{
   campaign: Campaign;
-}> = ({ campaign }) => {
+  campaignReport: ReportDataWithAuctions;
+}> = ({ campaign, campaignReport }) => {
   const { dispatch } = usePromotionContext();
   const days = useMemo(() => {
     const end = new Date(campaign.endDate);
@@ -32,7 +33,7 @@ export const Details: FunctionalComponent<{
         onEdit={() => dispatch({ type: "edit campaign button clicked" })}
       />
       <hr className="ts-hr" />
-      <Metrics title="Metrics" campaign={campaign} />
+      <Metrics title="Metrics" campaignReport={campaignReport} />
     </div>
   );
 };

--- a/src/components/CampaignDetails/Ending.tsx
+++ b/src/components/CampaignDetails/Ending.tsx
@@ -1,4 +1,4 @@
-import { Campaign } from "@api/types";
+import { Campaign, ReportDataWithAuctions } from "@api/types";
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { CampaignSummary } from "@components/common";
@@ -12,7 +12,8 @@ import { Metrics } from "./Metrics";
 
 export const Ending: FunctionalComponent<{
   campaign: Campaign;
-}> = ({ campaign }) => {
+  campaignReport: ReportDataWithAuctions;
+}> = ({ campaign, campaignReport }) => {
   const { authToken, vendorId, dispatch, state, centralServicesUrl } =
     usePromotionContext();
   const { selectedProductId } = state;
@@ -53,7 +54,7 @@ export const Ending: FunctionalComponent<{
   return (
     <div className="ts-space-y-4">
       <CampaignSummary />
-      <Metrics title="Final Metrics" campaign={campaign} />
+      <Metrics title="Final Metrics" campaignReport={campaignReport} />
       <div className="ts-space-y-2-5">
         {/*
           TODO (samet) Uncomment this and the related css once we fetch email

--- a/src/components/CampaignDetails/Ending.tsx
+++ b/src/components/CampaignDetails/Ending.tsx
@@ -1,4 +1,4 @@
-import { Campaign, ReportDataWithAuctions } from "@api/types";
+import { CampaignWithReport } from "@api/types";
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { CampaignSummary } from "@components/common";
@@ -11,9 +11,8 @@ import { useState } from "preact/hooks";
 import { Metrics } from "./Metrics";
 
 export const Ending: FunctionalComponent<{
-  campaign: Campaign;
-  campaignReport: ReportDataWithAuctions;
-}> = ({ campaign, campaignReport }) => {
+  campaign: CampaignWithReport;
+}> = ({ campaign }) => {
   const { authToken, vendorId, dispatch, state, centralServicesUrl } =
     usePromotionContext();
   const { selectedProductId } = state;
@@ -54,7 +53,7 @@ export const Ending: FunctionalComponent<{
   return (
     <div className="ts-space-y-4">
       <CampaignSummary />
-      <Metrics title="Final Metrics" campaignReport={campaignReport} />
+      <Metrics title="Final Metrics" campaignReport={campaign.report} />
       <div className="ts-space-y-2-5">
         {/*
           TODO (samet) Uncomment this and the related css once we fetch email

--- a/src/components/CampaignDetails/Metrics.tsx
+++ b/src/components/CampaignDetails/Metrics.tsx
@@ -1,14 +1,14 @@
-import { Campaign } from "@api/types";
+import { ReportDataWithAuctions } from "@api/types";
 import { Icon, IconName } from "@components/Icon";
 import { usePromotionContext } from "@context";
 import { FunctionalComponent } from "preact";
 
 export const Metrics: FunctionalComponent<{
-  campaign: Campaign;
+  campaignReport: ReportDataWithAuctions;
   title: string;
-}> = ({ campaign, title }) => {
+}> = ({ campaignReport, title }) => {
   const { formatMoney, formatNumber } = usePromotionContext();
-  const { impressions, clicks, purchases } = campaign.campaignBehaviorData;
+  const { impressions, clicks, purchases } = campaignReport;
   return (
     <div className="ts-metrics">
       <span className="ts-metrics__title">{title}</span>
@@ -33,12 +33,12 @@ export const Metrics: FunctionalComponent<{
         <Metric
           title="Total spend"
           // TODO(christopherbot) is this right? Tomi says: "we're not charging by impressions AFAIK"
-          value={formatMoney(clicks.adSpent + impressions.adSpent)}
+          value={formatMoney(Number(clicks.adSpent + impressions.adSpent))}
           iconName="money"
         />
         <Metric
           title="Total sales"
-          value={formatMoney(purchases.amount)}
+          value={formatMoney(Number(purchases.amount))}
           iconName="message-add"
         />
         <Metric

--- a/src/components/CampaignDetails/index.tsx
+++ b/src/components/CampaignDetails/index.tsx
@@ -55,6 +55,30 @@ export const CampaignDetails: FunctionalComponent<{
   }, [authToken, vendorId, campaign, campaignId, dispatch, centralServicesUrl]);
 
   useEffect(() => {
+    if (campaign.report) return;
+    async function getCampaignReport() {
+      try {
+        const campaignReport = await services.getCampaignReport(
+          centralServicesUrl,
+          authToken,
+          campaignId
+        );
+        dispatch({
+          type: "campaign report retrieved",
+          payload: { campaignId, report: campaignReport },
+        });
+      } catch (error) {
+        logger.error(
+          `Failed to get campaign report (id="${campaignId}").`,
+          error
+        );
+        setHasError(true);
+      }
+    }
+    getCampaignReport();
+  }, [campaignId, campaign, authToken, dispatch, centralServicesUrl]);
+
+  useEffect(() => {
     // If the modal for a different campaign is opened,
     // reset back to the first step
     return () => {
@@ -92,7 +116,11 @@ export const CampaignDetails: FunctionalComponent<{
       case "details": {
         return {
           title: "Campaign Details",
-          content: <Details campaign={campaign} />,
+          content: campaign.report ? (
+            <Details campaign={campaign} campaignReport={campaign.report} />
+          ) : (
+            <></>
+          ),
         };
       }
       case "editing": {
@@ -113,7 +141,11 @@ export const CampaignDetails: FunctionalComponent<{
       case "ending": {
         return {
           title: "You're about to end this campaign",
-          content: <Ending campaign={campaign} />,
+          content: campaign.report ? (
+            <Ending campaign={campaign} campaignReport={campaign.report} />
+          ) : (
+            <></>
+          ),
         };
       }
     }

--- a/src/components/CampaignDetails/index.tsx
+++ b/src/components/CampaignDetails/index.tsx
@@ -40,10 +40,15 @@ export const CampaignDetails: FunctionalComponent<{
           vendorId,
           campaignId
         );
+        const report = await services.getCampaignReport(
+          centralServicesUrl,
+          authToken,
+          campaignId
+        );
 
         dispatch({
           type: "campaign retrieved",
-          payload: { campaign },
+          payload: { campaign, report },
         });
       } catch (error) {
         logger.error(`Failed to get campaign (id="${campaignId}").`, error);
@@ -53,30 +58,6 @@ export const CampaignDetails: FunctionalComponent<{
 
     getCampaign();
   }, [authToken, vendorId, campaign, campaignId, dispatch, centralServicesUrl]);
-
-  useEffect(() => {
-    if (campaign.report) return;
-    async function getCampaignReport() {
-      try {
-        const campaignReport = await services.getCampaignReport(
-          centralServicesUrl,
-          authToken,
-          campaignId
-        );
-        dispatch({
-          type: "campaign report retrieved",
-          payload: { campaignId, report: campaignReport },
-        });
-      } catch (error) {
-        logger.error(
-          `Failed to get campaign report (id="${campaignId}").`,
-          error
-        );
-        setHasError(true);
-      }
-    }
-    getCampaignReport();
-  }, [campaignId, campaign, authToken, dispatch, centralServicesUrl]);
 
   useEffect(() => {
     // If the modal for a different campaign is opened,
@@ -116,11 +97,7 @@ export const CampaignDetails: FunctionalComponent<{
       case "details": {
         return {
           title: "Campaign Details",
-          content: campaign.report ? (
-            <Details campaign={campaign} campaignReport={campaign.report} />
-          ) : (
-            <></>
-          ),
+          content: <Details campaign={campaign} />,
         };
       }
       case "editing": {
@@ -141,11 +118,7 @@ export const CampaignDetails: FunctionalComponent<{
       case "ending": {
         return {
           title: "You're about to end this campaign",
-          content: campaign.report ? (
-            <Ending campaign={campaign} campaignReport={campaign.report} />
-          ) : (
-            <></>
-          ),
+          content: <Ending campaign={campaign} />,
         };
       }
     }

--- a/src/components/PromoteShop.tsx
+++ b/src/components/PromoteShop.tsx
@@ -54,9 +54,14 @@ export const PromoteShop: FunctionalComponent = () => {
       const campaign = res?.exists ? res.campaign : null;
       setStatus("success");
       if (campaign) {
+        const report = await services.getCampaignReport(
+          centralServicesUrl,
+          authToken,
+          campaign.campaignId
+        );
         dispatch({
           type: "campaign retrieved",
-          payload: { campaign },
+          payload: { campaign, report },
         });
         dispatch({
           type: "set shop campaign id",

--- a/src/components/Promotions.tsx
+++ b/src/components/Promotions.tsx
@@ -92,7 +92,7 @@ const TopsortPromotions: FunctionalComponent = () => {
           isCloseButtonHidden={!!lastDeletedCampaign}
         >
           {lastDeletedCampaign ? (
-            <CampaignEnded campaign={lastDeletedCampaign} />
+            <CampaignEnded campaignReport={lastDeletedCampaign.report} />
           ) : /*
            * Don't show the Details if the campaign was just launched so that
            * the user still sees the Launched screen in the creation flow

--- a/src/services/central-services/services.ts
+++ b/src/services/central-services/services.ts
@@ -10,6 +10,7 @@ import type {
   DefaultBudgetAndCpc,
   MarketplaceDetails,
   BaseCampaign,
+  ReportDataWithAuctions,
 } from "@api/types";
 
 import type { Services } from "./types";
@@ -98,6 +99,21 @@ async function getCampaign(
   );
 }
 
+async function getCampaignReport(
+  centralServicesUrl: string,
+  authToken: string,
+  campaignId: string
+): Promise<ReportDataWithAuctions> {
+  return await api(
+    schemas.reportingApiModels.reportDataWithAuctions,
+    paths.campaignReport(centralServicesUrl, campaignId),
+    {
+      method: "GET",
+      headers: getHeaders(authToken),
+    }
+  );
+}
+
 async function createProductCampaign(
   centralServicesUrl: string,
   authToken: string,
@@ -161,23 +177,6 @@ async function createProductCampaign(
   return {
     ...response,
     activeBidsCount: 1,
-    campaignBehaviorData: {
-      clicks: {
-        total: 0,
-        charged: 0,
-        adSpent: 0,
-      },
-      impressions: {
-        total: 0,
-        charged: 0,
-        adSpent: 0,
-      },
-      purchases: {
-        amount: 0,
-        count: 0,
-        quantity: 0,
-      },
-    },
   };
 }
 
@@ -293,6 +292,7 @@ export const services: Services = {
   getDefaultBudgetAndCpc,
   getCampaignIdsByProductId,
   getCampaign,
+  getCampaignReport,
   createProductCampaign,
   updateCampaign,
   endCampaign,

--- a/src/services/central-services/types.ts
+++ b/src/services/central-services/types.ts
@@ -5,6 +5,7 @@ import {
   DefaultBudgetAndCpc,
   CheckVendorCampaign,
   BaseCampaign,
+  ReportDataWithAuctions,
 } from "@api/types";
 
 export type Services = {
@@ -33,6 +34,11 @@ export type Services = {
     vendorId: string,
     campaignId: string
   ): Promise<Campaign>;
+  getCampaignReport(
+    centralServicesUrl: string,
+    authToken: string,
+    campaignId: string
+  ): Promise<ReportDataWithAuctions>;
   createProductCampaign(
     centralServicesUrl: string,
     authToken: string,

--- a/src/state.ts
+++ b/src/state.ts
@@ -252,7 +252,7 @@ export const reducer = (
       case "product campaign launched": {
         const { campaign, report, productId } = action.payload;
         draft.campaignIdsByProductId[productId] = campaign.campaignId;
-        draft.campaignsById[campaign.campaignId] = { ...campaign, report }
+        draft.campaignsById[campaign.campaignId] = { ...campaign, report };
         draft.campaignCreation.step = "launched";
         break;
       }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import {
   BaseCampaign,
   Campaign,
+  CampaignWithReport,
   DefaultBudgetAndCpc,
   ReportDataWithAuctions,
 } from "@api/types";
@@ -20,10 +21,6 @@ type ProductData = {
   imgUrl: string;
 };
 
-type CampaignWithReport = Campaign & {
-  report?: ReportDataWithAuctions;
-};
-
 export type State = {
   defaultBudget: DefaultBudgetAndCpc["defaultBudget"];
   marketplaceCpc: DefaultBudgetAndCpc["cpc"];
@@ -41,7 +38,7 @@ export type State = {
   campaignDetails: {
     step: CampaignDetailsStep;
   };
-  lastDeletedCampaign: Campaign | null;
+  lastDeletedCampaign: CampaignWithReport | null;
   selectedCampaignId: string | null;
   shopCampaignLaunched: boolean;
   shopCampaignId: string | null;
@@ -127,12 +124,6 @@ export type Action =
       type: "campaign retrieved";
       payload: {
         campaign: Campaign;
-      };
-    }
-  | {
-      type: "campaign report retrieved";
-      payload: {
-        campaignId: string;
         report: ReportDataWithAuctions;
       };
     }
@@ -153,6 +144,7 @@ export type Action =
       type: "product campaign launched";
       payload: {
         campaign: Campaign;
+        report: ReportDataWithAuctions;
         productId: string;
       };
     }
@@ -168,7 +160,7 @@ export type Action =
   | {
       type: "campaign ended";
       payload: {
-        campaign: Campaign;
+        campaign: CampaignWithReport;
         productId?: string;
       };
     };
@@ -221,13 +213,8 @@ export const reducer = (
         break;
       }
       case "campaign retrieved": {
-        const { campaign } = action.payload;
-        draft.campaignsById[campaign.campaignId] = campaign;
-        break;
-      }
-      case "campaign report retrieved": {
-        const { campaignId, report } = action.payload;
-        draft.campaignsById[campaignId].report = report;
+        const { campaign, report } = action.payload;
+        draft.campaignsById[campaign.campaignId] = { ...campaign, report };
         break;
       }
       case "set shopName": {
@@ -263,9 +250,9 @@ export const reducer = (
         break;
       }
       case "product campaign launched": {
-        const { campaign, productId } = action.payload;
+        const { campaign, report, productId } = action.payload;
         draft.campaignIdsByProductId[productId] = campaign.campaignId;
-        draft.campaignsById[campaign.campaignId] = campaign;
+        draft.campaignsById[campaign.campaignId] = { ...campaign, report }
         draft.campaignCreation.step = "launched";
         break;
       }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,9 @@
-import { BaseCampaign, Campaign, DefaultBudgetAndCpc } from "@api/types";
+import {
+  BaseCampaign,
+  Campaign,
+  DefaultBudgetAndCpc,
+  ReportDataWithAuctions,
+} from "@api/types";
 import { produce } from "structurajs";
 
 export const initialDurationDays = 15;
@@ -15,13 +20,17 @@ type ProductData = {
   imgUrl: string;
 };
 
+type CampaignWithReport = Campaign & {
+  report?: ReportDataWithAuctions;
+};
+
 export type State = {
   defaultBudget: DefaultBudgetAndCpc["defaultBudget"];
   marketplaceCpc: DefaultBudgetAndCpc["cpc"];
   productDataById: Record<string, ProductData>;
   isModalOpen: boolean;
   campaignIdsByProductId: Record<string, string | null>;
-  campaignsById: Record<string, Campaign>;
+  campaignsById: Record<string, CampaignWithReport>;
   selectedProductId: string | null;
   campaignCreation: {
     step: CampaignCreationStep;
@@ -120,6 +129,13 @@ export type Action =
         campaign: Campaign;
       };
     }
+  | {
+      type: "campaign report retrieved";
+      payload: {
+        campaignId: string;
+        report: ReportDataWithAuctions;
+      };
+    }
   | { type: "set shop campaign id"; payload: { campaignId: string } }
   | {
       type: "campaign creation daily budget updated";
@@ -207,6 +223,11 @@ export const reducer = (
       case "campaign retrieved": {
         const { campaign } = action.payload;
         draft.campaignsById[campaign.campaignId] = campaign;
+        break;
+      }
+      case "campaign report retrieved": {
+        const { campaignId, report } = action.payload;
+        draft.campaignsById[campaignId].report = report;
         break;
       }
       case "set shopName": {


### PR DESCRIPTION
- Remove behavior summary from campaign schema
- Create report schema from central's api models
- Change usage in components