### PR TITLE
Fix: Handle null budget

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -59,7 +59,7 @@ export const campaignBaseSchema = z.object({
   budget: z.object({
     amount: z.number(),
     type: z.enum(["daily", "weekly", "monthly"]),
-  }),
+  }).nullable(),
   startDate: z.string(),
   endDate: z.string(),
 });

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -56,10 +56,12 @@ export const reportingApiModels = (function () {
 export const campaignBaseSchema = z.object({
   campaignId: z.string().uuid(),
   name: z.string(),
-  budget: z.object({
-    amount: z.number(),
-    type: z.enum(["daily", "weekly", "monthly"]),
-  }).nullable(),
+  budget: z
+    .object({
+      amount: z.number(),
+      type: z.enum(["daily", "weekly", "monthly"]),
+    })
+    .nullable(),
   startDate: z.string(),
   endDate: z.string(),
 });

--- a/src/components/CampaignDetails/Details.tsx
+++ b/src/components/CampaignDetails/Details.tsx
@@ -27,7 +27,7 @@ export const Details: FunctionalComponent<{
     <div className="ts-space-y-3-5">
       <CampaignSummary startDate={campaign.startDate} />
       <CampaignBudget
-        budget={campaign.budget.amount}
+        budget={campaign.budget?.amount}
         days={days}
         onEdit={() => dispatch({ type: "edit campaign button clicked" })}
       />

--- a/src/components/CampaignDetails/Edit.tsx
+++ b/src/components/CampaignDetails/Edit.tsx
@@ -65,7 +65,12 @@ export const Edit: FunctionalComponent<{
     currency
   );
 
-  const defaultDailyBudget = useDefaultDailyBudget(campaign.budget);
+  const defaultDailyBudget = useDefaultDailyBudget(
+    campaign.budget ?? {
+      amount: 0,
+      type: "daily",
+    }
+  );
 
   const defaultDurationDays = useMemo(() => {
     const startDate = new Date(campaign.startDate);

--- a/src/components/common/CampaignBudget.tsx
+++ b/src/components/common/CampaignBudget.tsx
@@ -3,8 +3,8 @@ import { usePromotionContext } from "@context";
 import { FunctionalComponent } from "preact";
 
 export const CampaignBudget: FunctionalComponent<{
-  budget: number;
   days: number | "infinite";
+  budget?: number;
   onEdit?: () => void;
   showTargetingText?: boolean;
 }> = ({ budget, days, onEdit, showTargetingText = false }) => {
@@ -24,7 +24,7 @@ export const CampaignBudget: FunctionalComponent<{
         )}
       </div>
       <div class="ts-budget-duration">
-        {formatMoney(budget)} over{" "}
+        {budget != null ? formatMoney(budget) : "-"} over{" "}
         {typeof days === "number" ? days : "infinite"}{" "}
         {days === 1 ? "day" : "days"}
         {showTargetingText ? <span>with automatic targeting.</span> : "."}


### PR DESCRIPTION
The campaign service can give a nullable budget if not asked explicitly, this handles that possibility.