### PR TITLE
fix: switch to npm for publishing

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Publish to npm
         id: publish
         run: |
-          pnpm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          pnpm publish --access public --no-git-checks
+          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          npm publish --access public --no-git-checks
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
`pnpm` writes to a different config which ends up not being used by the publish job.

Note: hard to test. I'm crossing both arms and legs here. 