### PR TITLE
revert: fix: switch to npm for publishing

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Publish to npm
         id: publish
         run: |
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm publish --access public --no-git-checks
+          pnpm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          pnpm publish --access public --no-git-checks
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
This apparently wasn't needed since the NPM token was invalid.

This reverts commit 44f34c3601f7e544fad625533c5673c8d2b39140.